### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,5 +1,8 @@
 name: Validate with hassfest
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/jianyu-li/thermostat-proxy/security/code-scanning/1](https://github.com/jianyu-li/thermostat-proxy/security/code-scanning/1)

To address this problem, you should add a `permissions:` key specifying the least privileges necessary for the workflow's jobs. For maximum clarity and default least privilege, set it at the workflow level (top-level, after `name` and `on`), so all jobs inherit this unless overridden. Based on the typical need of actions like `actions/checkout` and the home-assistant hassfest action (which only read repository files, not write to contents or issues), `contents: read` is sufficient and smallest required for this pipeline. Edit `.github/workflows/hassfest.yaml` by inserting the `permissions:` block after the `name` (can be before or after `on`, but after is clearest), with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
