### PR TITLE
Support Dual Setpoints in Thermostat Proxy

### DIFF
--- a/custom_components/thermostat_proxy/climate.py
+++ b/custom_components/thermostat_proxy/climate.py
@@ -96,6 +96,9 @@ EXTERNAL_CHANGE_TOLERANCE = (
     0.2  # Degrees to ignore as noise/rounding for external detection
 )
 POST_WRITE_GRACE_PERIOD = 10.0  # Seconds to ignore external changes after a write
+REALIGN_TARGET_TOLERANCE = (
+    0.1  # Tolerance for "already at target" checks during realignment
+)
 
 # Attributes supplied by ClimateEntity itself that must NOT be overridden by
 # forwarding the physical thermostat's attributes, otherwise the front-end sees
@@ -118,7 +121,8 @@ _RESERVED_REAL_ATTRIBUTES = {
     "max_temp",
 }
 
-UNSUPPORTED_REMOTE_MODES = {HVACMode.AUTO, HVACMode.HEAT_COOL}
+# Extensibility hook: add HVACMode values here to block remote sensors in those modes.
+UNSUPPORTED_REMOTE_MODES: set[HVACMode] = set()
 
 SENSOR_SCHEMA = vol.Schema(
     {
@@ -339,6 +343,8 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
         )
         self._virtual_target_temperature: float | None = None
+        self._virtual_target_temperature_low: float | None = None
+        self._virtual_target_temperature_high: float | None = None
         self._temperature_unit: str | None = None
         self._real_state: State | None = None
         self._last_requested_real_target: float | None = None
@@ -346,6 +352,8 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             []
         )  # (target, timestamp)
         self._last_real_target_temp: float | None = None
+        self._last_real_target_temp_low: float | None = None
+        self._last_real_target_temp_high: float | None = None
         self._unsub_listeners: list[Callable[[], None]] = []
         self._min_temp: float | None = None
         self._max_temp: float | None = None
@@ -388,12 +396,29 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         self._temperature_unit = self._discover_temperature_unit()
         if self._last_real_target_temp is None:
             self._last_real_target_temp = self._get_real_target_temperature()
+        if self._last_real_target_temp_low is None:
+            self._last_real_target_temp_low = self._get_real_target_temperature_low()
+        if self._last_real_target_temp_high is None:
+            self._last_real_target_temp_high = self._get_real_target_temperature_high()
+
         if self._virtual_target_temperature is None:
             self._virtual_target_temperature = self._apply_target_constraints(
                 self._get_real_target_temperature()
                 or self._get_active_sensor_temperature()
                 or self._get_real_current_temperature()
             )
+        if self._virtual_target_temperature_low is None:
+            real_low = self._get_real_target_temperature_low()
+            if real_low is not None:
+                self._virtual_target_temperature_low = self._apply_target_constraints(
+                    real_low
+                )
+        if self._virtual_target_temperature_high is None:
+            real_high = self._get_real_target_temperature_high()
+            if real_high is not None:
+                self._virtual_target_temperature_high = self._apply_target_constraints(
+                    real_high
+                )
         self._enforce_hvac_mode_restrictions()
         await self._async_subscribe_to_states()
 
@@ -492,15 +517,67 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
 
         self._enforce_hvac_mode_restrictions(new_state.state)
 
+        mode_changed = old_state is not None and old_state.state != new_state.state
+
+        # Handle mode transition target sync between dual and single setpoint modes
+        if mode_changed and old_state is not None:
+            old_mode_str = old_state.state
+            new_mode_str = new_state.state
+            if old_mode_str in (HVACMode.HEAT_COOL, HVACMode.AUTO) and new_mode_str in (
+                HVACMode.COOL,
+                HVACMode.HEAT,
+            ):
+                if new_mode_str == HVACMode.COOL:
+                    if self._virtual_target_temperature_high is not None:
+                        self._virtual_target_temperature = (
+                            self._virtual_target_temperature_high
+                        )
+                    else:
+                        rt = self._get_real_target_temperature()
+                        if rt is not None:
+                            self._virtual_target_temperature = (
+                                self._apply_target_constraints(rt)
+                            )
+                elif new_mode_str == HVACMode.HEAT:
+                    if self._virtual_target_temperature_low is not None:
+                        self._virtual_target_temperature = (
+                            self._virtual_target_temperature_low
+                        )
+                    else:
+                        rt = self._get_real_target_temperature()
+                        if rt is not None:
+                            self._virtual_target_temperature = (
+                                self._apply_target_constraints(rt)
+                            )
+            elif old_mode_str in (HVACMode.COOL, HVACMode.HEAT) and new_mode_str in (
+                HVACMode.HEAT_COOL,
+                HVACMode.AUTO,
+            ):
+                if (
+                    old_mode_str == HVACMode.COOL
+                    and self._virtual_target_temperature is not None
+                ):
+                    self._virtual_target_temperature_high = (
+                        self._virtual_target_temperature
+                    )
+                elif (
+                    old_mode_str == HVACMode.HEAT
+                    and self._virtual_target_temperature is not None
+                ):
+                    self._virtual_target_temperature_low = (
+                        self._virtual_target_temperature
+                    )
+
         self._temperature_unit = self._discover_temperature_unit()
         real_target = self._get_real_target_temperature()
 
-        # Check if the device just became available or switched from Off
+        # Check if the device just became available, switched from Off, or changed HVAC mode
         was_not_controlling = old_state is None or old_state.state in (
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
             HVACMode.OFF,
         )
+        skip_external_change = was_not_controlling or mode_changed
 
         if real_target is not None:
             previous_real_target = self._last_real_target_temp
@@ -527,9 +604,9 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                 time_since_write = time.monotonic() - self._last_real_write_time
                 is_recent_write = time_since_write < POST_WRITE_GRACE_PERIOD
 
-                if was_not_controlling:
+                if skip_external_change:
                     self._log_debug(
-                        "Thermostat returned to active state; updated target to %s without triggering external change",
+                        "Thermostat mode changed or returned to active state; updated target to %s without triggering external change",
                         real_target,
                     )
                 elif is_recent_write:
@@ -561,6 +638,14 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                         )
             else:
                 self._log_debug("Initial real target captured: %s", real_target)
+
+        # Track dual setpoint changes on the physical thermostat
+        real_target_low = self._get_real_target_temperature_low()
+        real_target_high = self._get_real_target_temperature_high()
+        if real_target_low is not None or real_target_high is not None:
+            self._detect_external_dual_target_change(
+                real_target_low, real_target_high, skip_external_change
+            )
 
         self._schedule_target_realign()
         self.async_write_ha_state()
@@ -648,6 +733,106 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         self._selected_sensor_name = self._physical_sensor_name
         self.async_write_ha_state()
 
+        self.hass.async_create_task(
+            self._async_log_physical_override(real_target, switched)
+        )
+
+    def _detect_external_dual_target_change(
+        self,
+        real_low: float | None,
+        real_high: float | None,
+        was_not_controlling: bool,
+    ) -> None:
+        """Detect and react to external changes to dual setpoint targets."""
+
+        previous_low = self._last_real_target_temp_low
+        previous_high = self._last_real_target_temp_high
+
+        if real_low is not None:
+            self._last_real_target_temp_low = real_low
+        if real_high is not None:
+            self._last_real_target_temp_high = real_high
+
+        if was_not_controlling:
+            return
+
+        time_since_write = time.monotonic() - self._last_real_write_time
+        if time_since_write < POST_WRITE_GRACE_PERIOD:
+            return
+
+        abs_tol = (
+            (self._target_temp_step * 0.5)
+            if self._target_temp_step
+            else EXTERNAL_CHANGE_TOLERANCE
+        )
+
+        strict_tolerance = self._pending_request_tolerance()
+        loose_tolerance = max(
+            PENDING_REQUEST_TOLERANCE_MAX,
+            (self._target_temp_step or 0) * 0.75,
+        )
+
+        low_changed = (
+            real_low is not None
+            and previous_low is not None
+            and not math.isclose(real_low, previous_low, abs_tol=abs_tol)
+            and not self._consume_real_target_request(real_low, strict_tolerance)
+            and not self._has_pending_real_target_request(real_low, loose_tolerance)
+        )
+        high_changed = (
+            real_high is not None
+            and previous_high is not None
+            and not math.isclose(real_high, previous_high, abs_tol=abs_tol)
+            and not self._consume_real_target_request(real_high, strict_tolerance)
+            and not self._has_pending_real_target_request(real_high, loose_tolerance)
+        )
+
+        if not low_changed and not high_changed:
+            return
+
+        _LOGGER.info(
+            "Detected external dual setpoint change: low %s -> %s, high %s -> %s",
+            previous_low,
+            real_low,
+            previous_high,
+            real_high,
+        )
+
+        if (
+            self._disable_auto_switch
+            and self._selected_sensor_name != self._physical_sensor_name
+        ):
+            if low_changed and previous_low is not None and real_low is not None:
+                delta = real_low - previous_low
+                if self._virtual_target_temperature_low is not None:
+                    derived = self._virtual_target_temperature_low + delta
+                    new_low = self._apply_target_constraints(derived)
+                    if new_low is not None:
+                        self._virtual_target_temperature_low = new_low
+            if high_changed and previous_high is not None and real_high is not None:
+                delta = real_high - previous_high
+                if self._virtual_target_temperature_high is not None:
+                    derived = self._virtual_target_temperature_high + delta
+                    new_high = self._apply_target_constraints(derived)
+                    if new_high is not None:
+                        self._virtual_target_temperature_high = new_high
+            self.async_write_ha_state()
+            return
+
+        if real_low is not None:
+            self._virtual_target_temperature_low = self._apply_target_constraints(
+                real_low
+            )
+        if real_high is not None:
+            self._virtual_target_temperature_high = self._apply_target_constraints(
+                real_high
+            )
+
+        switched = self._selected_sensor_name != self._physical_sensor_name
+        self._selected_sensor_name = self._physical_sensor_name
+        self.async_write_ha_state()
+
+        real_target = self._get_real_target_temperature()
         self.hass.async_create_task(
             self._async_log_physical_override(real_target, switched)
         )
@@ -755,6 +940,20 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         else:
             self._mark_entity_health(self._real_entity_id, True)
         return value
+
+    def _get_real_target_temperature_low(self) -> float | None:
+        if not self._real_state:
+            return None
+        return _coerce_temperature(
+            self._real_state.attributes.get(ATTR_TARGET_TEMP_LOW)
+        )
+
+    def _get_real_target_temperature_high(self) -> float | None:
+        if not self._real_state:
+            return None
+        return _coerce_temperature(
+            self._real_state.attributes.get(ATTR_TARGET_TEMP_HIGH)
+        )
 
     def _get_real_current_humidity(self) -> float | None:
         if not self._real_state:
@@ -871,27 +1070,37 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         )
 
     @property
+    def is_range_mode(self) -> bool:
+        """Return True if active HVAC mode uses range (dual) setpoints."""
+        if not (
+            self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        ):
+            return False
+        return self.hvac_mode in (HVACMode.HEAT_COOL, HVACMode.AUTO)
+
+    @property
     def target_temperature(self) -> float | None:
-        if self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:
-            if self.hvac_mode in UNSUPPORTED_REMOTE_MODES:
-                return None
-        return self._virtual_target_temperature
+        if self.is_range_mode:
+            return None
+        if self._virtual_target_temperature is not None:
+            return self._virtual_target_temperature
+        return self._get_real_target_temperature()
 
     @property
     def target_temperature_high(self) -> float | None:
-        if not self._real_state:
-            return None
-        return _coerce_temperature(
-            self._real_state.attributes.get(ATTR_TARGET_TEMP_HIGH)
-        )
+        if self.is_range_mode:
+            if self._virtual_target_temperature_high is not None:
+                return self._virtual_target_temperature_high
+            return self._get_real_target_temperature_high()
+        return None
 
     @property
     def target_temperature_low(self) -> float | None:
-        if not self._real_state:
-            return None
-        return _coerce_temperature(
-            self._real_state.attributes.get(ATTR_TARGET_TEMP_LOW)
-        )
+        if self.is_range_mode:
+            if self._virtual_target_temperature_low is not None:
+                return self._virtual_target_temperature_low
+            return self._get_real_target_temperature_low()
+        return None
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -986,30 +1195,42 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             low = kwargs.get(ATTR_TARGET_TEMP_LOW)
 
             if high is not None or low is not None:
-                # Security/Safety: Dual setpoints only allowed on physical sensor
-                if self._selected_sensor_name != self._physical_sensor_name:
-                    raise ValueError(
-                        f"Dual setpoint adjustment is only supported when using the {self._physical_sensor_name} preset"
-                    )
+                requested_high = _coerce_temperature(high)
+                requested_low = _coerce_temperature(low)
+
+                display_current = self.current_temperature
+                real_current = self._get_real_current_temperature()
 
                 payload = {ATTR_ENTITY_ID: self._real_entity_id}
-                if high is not None:
-                    payload[ATTR_TARGET_TEMP_HIGH] = self._apply_target_constraints(
-                        _coerce_temperature(high)
+                parts = []
+
+                if requested_high is not None:
+                    constrained_high, real_high = (
+                        self._calculate_dual_target_real_temperature(
+                            requested_high, display_current, real_current
+                        )
                     )
-                if low is not None:
-                    payload[ATTR_TARGET_TEMP_LOW] = self._apply_target_constraints(
-                        _coerce_temperature(low)
+                    if constrained_high is not None and real_high is not None:
+                        payload[ATTR_TARGET_TEMP_HIGH] = real_high
+                        parts.append(f"High={constrained_high}")
+                        self._virtual_target_temperature_high = constrained_high
+
+                if requested_low is not None:
+                    constrained_low, real_low = (
+                        self._calculate_dual_target_real_temperature(
+                            requested_low, display_current, real_current
+                        )
                     )
+                    if constrained_low is not None and real_low is not None:
+                        payload[ATTR_TARGET_TEMP_LOW] = real_low
+                        parts.append(f"Low={constrained_low}")
+                        self._virtual_target_temperature_low = constrained_low
 
                 if ATTR_HVAC_MODE in kwargs and kwargs[ATTR_HVAC_MODE] is not None:
                     payload[ATTR_HVAC_MODE] = kwargs[ATTR_HVAC_MODE]
 
-                parts = []
-                if high is not None:
-                    parts.append(f"High={payload[ATTR_TARGET_TEMP_HIGH]}")
-                if low is not None:
-                    parts.append(f"Low={payload[ATTR_TARGET_TEMP_LOW]}")
+                actor_name = await self._get_actor_name()
+                suffix = f" (by {actor_name})" if actor_name else ""
 
                 await self.hass.services.async_call(
                     LOGBOOK_DOMAIN,
@@ -1017,10 +1238,18 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                     {
                         "name": self.name,
                         "entity_id": self.entity_id,
-                        "message": f"Updated dual setpoints: {', '.join(parts)}",
+                        "message": f"Updated dual setpoints: {', '.join(parts)}{suffix}",
                     },
                     blocking=False,
                 )
+
+                if ATTR_TARGET_TEMP_HIGH in payload:
+                    self._record_real_target_request(payload[ATTR_TARGET_TEMP_HIGH])
+                if ATTR_TARGET_TEMP_LOW in payload:
+                    self._record_real_target_request(payload[ATTR_TARGET_TEMP_LOW])
+
+                self._last_real_write_time = time.monotonic()
+                self._start_auto_sync_log_suppression()
 
                 await self.hass.services.async_call(
                     CLIMATE_DOMAIN,
@@ -1335,11 +1564,18 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
     async def _async_realign_real_target_from_sensor(self, retry: bool = False) -> None:
         """Push a new target temperature to the real thermostat based on the active sensor."""
 
-        if self._virtual_target_temperature is None:
-            return
-
-        if self.hvac_mode in UNSUPPORTED_REMOTE_MODES:
-            return
+        if self.is_range_mode:
+            if (
+                self._virtual_target_temperature_low is None
+                and self._virtual_target_temperature_high is None
+            ):
+                return
+        elif self._virtual_target_temperature is None:
+            self._virtual_target_temperature = self._apply_target_constraints(
+                self._get_real_target_temperature()
+            )
+            if self._virtual_target_temperature is None:
+                return
 
         now = time.monotonic()
         if self._cooldown_period > 0:
@@ -1374,6 +1610,10 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             )
 
             if sensor_temp is None or real_current is None:
+                return
+
+            if self.is_range_mode:
+                await self._async_realign_dual_targets(sensor_temp, real_current)
                 return
 
             delta = self._virtual_target_temperature - sensor_temp
@@ -1451,7 +1691,7 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             current_real_target = self._get_real_target_temperature()
             # We must be strict here; if the step is 1.0, 66 vs 67 must be seen as different.
             # Using self.precision (1.0) as tolerance caused isclose(66, 67, abs_tol=1.0) -> True.
-            target_tolerance = 0.1
+            target_tolerance = REALIGN_TARGET_TOLERANCE
 
             # If we are in overdrive, we might be pushing AWAY from the "correct" delta-based target
             # So we should generally update if there's a difference.
@@ -1524,6 +1764,209 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                         err,
                     )
 
+    async def _async_realign_dual_targets(
+        self, sensor_temp: float, real_current: float
+    ) -> None:
+        """Handle realignment when physical thermostat is in dual setpoint mode."""
+
+        delta_low = (
+            self._virtual_target_temperature_low - sensor_temp
+            if self._virtual_target_temperature_low is not None
+            else None
+        )
+        delta_high = (
+            self._virtual_target_temperature_high - sensor_temp
+            if self._virtual_target_temperature_high is not None
+            else None
+        )
+
+        if self._max_sync_offset:
+            if delta_low is not None:
+                delta_low = max(
+                    -self._max_sync_offset, min(delta_low, self._max_sync_offset)
+                )
+            if delta_high is not None:
+                delta_high = max(
+                    -self._max_sync_offset, min(delta_high, self._max_sync_offset)
+                )
+
+        calculated_real_low = (
+            real_current + delta_low if delta_low is not None else None
+        )
+        calculated_real_high = (
+            real_current + delta_high if delta_high is not None else None
+        )
+
+        overdrive_adjust_low = 0.0
+        overdrive_adjust_high = 0.0
+
+        if self._real_state and self.hvac_mode in (
+            HVACMode.HEAT,
+            HVACMode.COOL,
+            HVACMode.HEAT_COOL,
+            HVACMode.AUTO,
+        ):
+            real_action = self._real_state.attributes.get(ATTR_HVAC_ACTION)
+            tolerance = max(self.precision or DEFAULT_PRECISION, 0.1)
+
+            if (
+                self._virtual_target_temperature_low is not None
+                and calculated_real_low is not None
+            ):
+                want_heat = sensor_temp < (
+                    self._virtual_target_temperature_low - tolerance
+                )
+                not_heating = real_action != HVACAction.HEATING
+                if want_heat and not_heating:
+                    overdrive_adjust_low = OVERDRIVE_ADJUSTMENT_HEAT
+                    _LOGGER.info(
+                        "Overdrive active (dual low): Heating required but thermostat idle. Applying +%s offset.",
+                        overdrive_adjust_low,
+                    )
+
+            if (
+                self._virtual_target_temperature_high is not None
+                and calculated_real_high is not None
+            ):
+                want_cool = sensor_temp > (
+                    self._virtual_target_temperature_high + tolerance
+                )
+                not_cooling = real_action != HVACAction.COOLING
+                if want_cool and not_cooling:
+                    overdrive_adjust_high = OVERDRIVE_ADJUSTMENT_COOL
+                    _LOGGER.info(
+                        "Overdrive active (dual high): Cooling required but thermostat idle. Applying %s offset.",
+                        overdrive_adjust_high,
+                    )
+
+        if calculated_real_low is not None and overdrive_adjust_low != 0.0:
+            calculated_real_low += overdrive_adjust_low
+        if calculated_real_high is not None and overdrive_adjust_high != 0.0:
+            calculated_real_high += overdrive_adjust_high
+
+        desired_real_low = (
+            self._apply_target_constraints(
+                self._apply_safety_clamp(calculated_real_low)
+            )
+            if calculated_real_low is not None
+            else None
+        )
+        desired_real_high = (
+            self._apply_target_constraints(
+                self._apply_safety_clamp(calculated_real_high)
+            )
+            if calculated_real_high is not None
+            else None
+        )
+
+        current_real_low = self._get_real_target_temperature_low()
+        current_real_high = self._get_real_target_temperature_high()
+        target_tolerance = REALIGN_TARGET_TOLERANCE
+
+        low_matches = desired_real_low is None or (
+            current_real_low is not None
+            and math.isclose(
+                current_real_low, desired_real_low, abs_tol=target_tolerance
+            )
+        )
+        high_matches = desired_real_high is None or (
+            current_real_high is not None
+            and math.isclose(
+                current_real_high, desired_real_high, abs_tol=target_tolerance
+            )
+        )
+
+        if low_matches and high_matches:
+            return
+
+        pending_tolerance = self._pending_request_tolerance()
+        if desired_real_low is not None and self._has_pending_real_target_request(
+            desired_real_low, pending_tolerance
+        ):
+            if desired_real_high is None or self._has_pending_real_target_request(
+                desired_real_high, pending_tolerance
+            ):
+                return
+
+        payload = {ATTR_ENTITY_ID: self._real_entity_id}
+        parts = []
+        if desired_real_low is not None:
+            payload[ATTR_TARGET_TEMP_LOW] = desired_real_low
+            parts.append(f"Low={desired_real_low}")
+            self._record_real_target_request(desired_real_low)
+        if desired_real_high is not None:
+            payload[ATTR_TARGET_TEMP_HIGH] = desired_real_high
+            parts.append(f"High={desired_real_high}")
+            self._record_real_target_request(desired_real_high)
+
+        overdrive_active = overdrive_adjust_low != 0.0 or overdrive_adjust_high != 0.0
+        reason = "dual setpoint realignment"
+        if overdrive_active:
+            reason += " (overdrive)"
+
+        unit = self.temperature_unit or ""
+        message = (
+            "Adjusted dual setpoints on %s to %s (%s): sensor=%s%s, real_current=%s%s"
+            % (
+                self._real_entity_id,
+                ", ".join(parts),
+                reason,
+                sensor_temp,
+                unit,
+                real_current,
+                unit,
+            )
+        )
+        _LOGGER.info("%s %s", self.entity_id, message)
+        await self.hass.services.async_call(
+            LOGBOOK_DOMAIN,
+            LOGBOOK_SERVICE_LOG,
+            {
+                "name": self.name,
+                "entity_id": self.entity_id,
+                "message": message,
+            },
+            blocking=False,
+        )
+
+        previous_state = (
+            self._last_real_write_time,
+            self._suppress_sync_logs_until,
+        )
+
+        self._last_real_write_time = time.monotonic()
+        self._start_auto_sync_log_suppression()
+
+        try:
+            await self.hass.services.async_call(
+                CLIMATE_DOMAIN,
+                SERVICE_SET_TEMPERATURE,
+                payload,
+                blocking=True,
+            )
+        except Exception as err:
+            (
+                self._last_real_write_time,
+                self._suppress_sync_logs_until,
+            ) = previous_state
+            if desired_real_low is not None:
+                self._remove_real_target_request(desired_real_low)
+            if desired_real_high is not None:
+                self._remove_real_target_request(desired_real_high)
+
+            if "502" in str(err) or "Bad Gateway" in str(err):
+                _LOGGER.warning(
+                    "Failed to set dual setpoints on %s (502 Bad Gateway) - will retry on next sync",
+                    self._real_entity_id,
+                )
+            else:
+                _LOGGER.error(
+                    "Error setting %s dual setpoints to %s: %s",
+                    self._real_entity_id,
+                    ", ".join(parts),
+                    err,
+                )
+
     @callback
     def _async_cooldown_retry(self, _now: datetime.datetime) -> None:
         """Retry the alignment after cooldown expires."""
@@ -1549,6 +1992,22 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         if restored_virtual is not None:
             self._virtual_target_temperature = self._apply_target_constraints(
                 restored_virtual
+            )
+
+        restored_virtual_low = _coerce_temperature(
+            last_state.attributes.get(ATTR_TARGET_TEMP_LOW)
+        )
+        if restored_virtual_low is not None:
+            self._virtual_target_temperature_low = self._apply_target_constraints(
+                restored_virtual_low
+            )
+
+        restored_virtual_high = _coerce_temperature(
+            last_state.attributes.get(ATTR_TARGET_TEMP_HIGH)
+        )
+        if restored_virtual_high is not None:
+            self._virtual_target_temperature_high = self._apply_target_constraints(
+                restored_virtual_high
             )
 
         restored_real = _coerce_temperature(
@@ -1680,6 +2139,29 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                     )
 
                 self.hass.async_create_task(_log_recovery())
+
+    def _calculate_dual_target_real_temperature(
+        self,
+        requested_temp: float,
+        display_current: float | None,
+        real_current: float | None,
+    ) -> tuple[float | None, float | None]:
+        """Calculate constrained virtual setpoint and real setpoint for dual setpoints."""
+        constrained = self._apply_target_constraints(requested_temp)
+        if constrained is None:
+            return None, None
+        if display_current is not None and real_current is not None:
+            delta = constrained - display_current
+            if self._max_sync_offset and abs(delta) > self._max_sync_offset:
+                raise ValueError(
+                    f"Requested target {constrained} requires an offset of {abs(delta)}°, "
+                    f"which exceeds max_sync_offset ({self._max_sync_offset}°)."
+                )
+            calc_real = real_current + delta
+        else:
+            calc_real = constrained
+        real_temp = self._apply_target_constraints(self._apply_safety_clamp(calc_real))
+        return constrained, real_temp
 
     def _apply_target_constraints(self, value: float | None) -> float | None:
         if value is None:

--- a/tests/components/thermostat_proxy/test_climate.py
+++ b/tests/components/thermostat_proxy/test_climate.py
@@ -1,10 +1,12 @@
 """Tests for the Thermostat Proxy climate platform."""
-from unittest.mock import AsyncMock, MagicMock, patch
+
+from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from homeassistant.core import HomeAssistant, State
 from homeassistant.components.climate import ClimateEntityFeature, HVACMode
-from custom_components.thermostat_proxy.climate import CustomThermostatEntity, SensorConfig
+from custom_components.thermostat_proxy.climate import CustomThermostatEntity
+
 
 @pytest.fixture
 def mock_hass():
@@ -16,11 +18,12 @@ def mock_hass():
     hass.services = AsyncMock()
     return hass
 
+
 def create_proxy(hass, thermostat="climate.real", sensors=None, target_temp_step=1.0):
     """Helper to create a configured CustomThermostatEntity."""
     if sensors is None:
         sensors = [{"name": "Sensor 1", "entity_id": "sensor.1"}]
-        
+
     proxy = CustomThermostatEntity(
         hass=hass,
         name="Test Proxy",
@@ -31,7 +34,7 @@ def create_proxy(hass, thermostat="climate.real", sensors=None, target_temp_step
         physical_sensor_name="Physical",
         use_last_active_sensor=False,
     )
-    
+
     # Mock physical thermostat state
     mock_real_state = State(
         thermostat,
@@ -41,62 +44,78 @@ def create_proxy(hass, thermostat="climate.real", sensors=None, target_temp_step
             "temperature": 22.0,
             "target_temp_step": target_temp_step,
             "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+        },
     )
-    hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == thermostat else None
+    hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == thermostat else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
-    
+
     return proxy
+
 
 @pytest.mark.asyncio
 async def test_infer_sensor_precision(mock_hass):
     """Test inference of sensor precision from state string."""
     proxy = create_proxy(mock_hass)
-    
+
     assert proxy._infer_sensor_precision(State("sensor.1", "22.8")) == 0.1
     assert proxy._infer_sensor_precision(State("sensor.1", "22.85")) == 0.01
     assert proxy._infer_sensor_precision(State("sensor.1", "22.0")) == 0.1
     assert proxy._infer_sensor_precision(State("sensor.1", "22")) == 1.0
-    assert proxy._infer_sensor_precision(State("sensor.1", "unknown")) == 0.1 # DEFAULT_PRECISION
+    assert (
+        proxy._infer_sensor_precision(State("sensor.1", "unknown")) == 0.1
+    )  # DEFAULT_PRECISION
+
 
 @pytest.mark.asyncio
 async def test_effective_precision_coarsest_wins(mock_hass):
     """Test that precision and target_temp_step use the coarsest available."""
     proxy = create_proxy(mock_hass, target_temp_step=0.5)
-    
+
     # Sensor 1 reports 1.0 precision
-    mock_hass.states.get.side_effect = lambda entity_id: State(entity_id, "22") if entity_id == "sensor.1" else proxy._real_state
-    
+    mock_hass.states.get.side_effect = lambda entity_id: (
+        State(entity_id, "22") if entity_id == "sensor.1" else proxy._real_state
+    )
+
     proxy._sensor_states["sensor.1"] = State("sensor.1", "22")
-    proxy._sensor_precisions["sensor.1"] = proxy._infer_sensor_precision(State("sensor.1", "22"))
+    proxy._sensor_precisions["sensor.1"] = proxy._infer_sensor_precision(
+        State("sensor.1", "22")
+    )
     proxy._selected_sensor_name = "Sensor 1"
-    
+
     # Thermostat is 0.5, Sensor is 1.0 -> Effective is 1.0
     assert proxy.precision == 1.0
     assert proxy.target_temperature_step == 1.0
-    
+
     # Switch to high precision sensor
     proxy._sensor_states["sensor.1"] = State("sensor.1", "22.85")
-    proxy._sensor_precisions["sensor.1"] = proxy._infer_sensor_precision(State("sensor.1", "22.85"))
-    
+    proxy._sensor_precisions["sensor.1"] = proxy._infer_sensor_precision(
+        State("sensor.1", "22.85")
+    )
+
     # Thermostat is 0.5, Sensor is 0.01 -> Display precision is 0.01, target step is 0.5
     assert proxy.precision == 0.01
     assert proxy.target_temperature_step == 0.5
+
 
 @pytest.mark.asyncio
 async def test_log_formatting_preserves_decimals(mock_hass):
     """Test that math formatting methods preserve exactly one decimal place."""
     proxy = create_proxy(mock_hass)
     proxy._precision_override = 0.5
-    
+
     # Output should always have .1f
     res = proxy._format_math_sensor_virtual(22.0, 20.0, "°C")
     assert res == "22.0°C - 20.0°C = 2.0°C"
-    
-    res = proxy._format_math_real_adjustment(25.0, 22.5, 20.0, 27.5, "°C", overdrive_adjust=1.0)
+
+    res = proxy._format_math_real_adjustment(
+        25.0, 22.5, 20.0, 27.5, "°C", overdrive_adjust=1.0
+    )
     assert res == "25.0°C - 2.5°C (+1.0 overdrive) = 27.5°C"
-    
+
+
 @pytest.mark.asyncio
 async def test_pending_request_tolerance_covers_step(mock_hass):
     """Test that _pending_request_tolerance does not incorrectly incorporate target_temp_step to avoid ignoring manual changes."""

--- a/tests/components/thermostat_proxy/test_config_flow.py
+++ b/tests/components/thermostat_proxy/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Thermostat Proxy config flow."""
-from unittest.mock import patch, AsyncMock
+
+from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
@@ -7,14 +8,21 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.thermostat_proxy.const import DOMAIN, CONF_THERMOSTAT, CONF_SENSORS, CONF_SENSOR_NAME, CONF_SENSOR_ENTITY_ID, CONF_PHYSICAL_SENSOR_NAME, CONF_COOLDOWN_PERIOD
-from custom_components.thermostat_proxy import config_flow
+from custom_components.thermostat_proxy.const import (
+    DOMAIN,
+    CONF_THERMOSTAT,
+    CONF_SENSORS,
+    CONF_PHYSICAL_SENSOR_NAME,
+    CONF_COOLDOWN_PERIOD,
+)
+
 
 @pytest.fixture(autouse=True)
 def mock_services():
     """Mock service calls to avoid ServiceNotFound errors."""
     with patch("homeassistant.core.ServiceRegistry.async_call", return_value=True):
         yield
+
 
 @pytest.mark.asyncio
 async def test_user_flow_success(hass: HomeAssistant) -> None:

--- a/tests/components/thermostat_proxy/test_dual_setpoint.py
+++ b/tests/components/thermostat_proxy/test_dual_setpoint.py
@@ -1,0 +1,239 @@
+"""Tests for Thermostat Proxy dual setpoint mode (HEAT_COOL and AUTO)."""
+
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from homeassistant.core import HomeAssistant, State, CoreState
+from homeassistant.components.climate import HVACMode, ClimateEntityFeature, HVACAction
+
+from custom_components.thermostat_proxy.climate import CustomThermostatEntity
+
+
+@pytest.fixture
+def mock_hass():
+    """Mock Home Assistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.state = CoreState.running
+    hass.data = {}
+    hass.states = MagicMock()
+    hass.config = MagicMock()
+    hass.config.units.temperature_unit = "°C"
+    hass.services = AsyncMock()
+    hass.async_create_task.side_effect = lambda coro: coro.close()
+    return hass
+
+
+def create_dual_proxy(hass, thermostat="climate.real", hvac_mode=HVACMode.HEAT_COOL):
+    """Helper to create a configured CustomThermostatEntity in dual setpoint mode."""
+    proxy = CustomThermostatEntity(
+        hass=hass,
+        name="Test Proxy",
+        real_thermostat=thermostat,
+        sensors=[{"name": "Remote", "entity_id": "sensor.remote"}],
+        default_sensor="Remote",
+        unique_id="123",
+        physical_sensor_name="Physical",
+        use_last_active_sensor=False,
+    )
+    proxy.entity_id = "climate.test_proxy"
+    proxy.async_write_ha_state = MagicMock()
+
+    mock_real_state = State(
+        thermostat,
+        hvac_mode,
+        {
+            "current_temperature": 20.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
+            "target_temp_step": 1.0,
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+                | ClimateEntityFeature.PRESET_MODE
+            ),
+        },
+    )
+    hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == thermostat else None
+    )
+    proxy._real_state = mock_real_state
+    proxy._update_real_temperature_limits()
+    proxy._temperature_unit = "°C"
+    proxy._sensor_states["sensor.remote"] = State("sensor.remote", "18.0")
+    proxy._virtual_target_temperature_low = 18.0
+    proxy._virtual_target_temperature_high = 24.0
+    proxy._selected_sensor_name = "Remote"
+    return proxy
+
+
+@pytest.mark.parametrize("hvac_mode", [HVACMode.HEAT_COOL, HVACMode.AUTO])
+@pytest.mark.asyncio
+async def test_dual_setpoint_preset_mode_switch(mock_hass, hvac_mode):
+    """Test switching preset mode in range modes (HEAT_COOL / AUTO)."""
+    proxy = create_dual_proxy(mock_hass, hvac_mode=hvac_mode)
+
+    # Preset should allow Remote sensor in range mode
+    assert proxy.preset_mode == "Remote"
+    assert proxy.target_temperature_low == 18.0
+    assert proxy.target_temperature_high == 24.0
+
+    # Switching to physical
+    await proxy.async_set_preset_mode("Physical")
+    assert proxy.preset_mode == "Physical"
+
+    # Switching back to remote
+    await proxy.async_set_preset_mode("Remote")
+    assert proxy.preset_mode == "Remote"
+
+
+@pytest.mark.parametrize("hvac_mode", [HVACMode.HEAT_COOL, HVACMode.AUTO])
+@pytest.mark.asyncio
+async def test_dual_setpoint_set_temperature(mock_hass, hvac_mode):
+    """Test set_temperature with low and high targets across range modes."""
+    proxy = create_dual_proxy(mock_hass, hvac_mode=hvac_mode)
+
+    # Physical current = 20.0, Remote sensor = 18.0 (diff = +2.0)
+    # Requested remote range: low = 19.0, high = 25.0
+    # Expected real target: low = 21.0, high = 27.0
+    await proxy.async_set_temperature(target_temp_low=19.0, target_temp_high=25.0)
+
+    assert mock_hass.services.async_call.called
+    args, kwargs = mock_hass.services.async_call.call_args
+    assert args[0] == "climate"
+    assert args[1] == "set_temperature"
+    assert args[2]["target_temp_low"] == 21.0
+    assert args[2]["target_temp_high"] == 27.0
+    assert proxy.target_temperature_low == 19.0
+    assert proxy.target_temperature_high == 25.0
+
+
+@pytest.mark.asyncio
+async def test_dual_setpoint_realignment(mock_hass):
+    """Test remote sensor realignment in dual setpoint mode."""
+    proxy = create_dual_proxy(mock_hass)
+
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.HEAT_COOL,
+        {
+            "current_temperature": 20.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
+            "hvac_action": "heating",
+            "target_temp_step": 1.0,
+            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        },
+    )
+
+    # Remote sensor changes from 18.0 to 16.0 (2° colder than physical 20.0, delta = +4.0)
+    proxy._sensor_states["sensor.remote"] = State("sensor.remote", "16.0")
+
+    # Virtual low = 18.0, virtual high = 24.0
+    # Calculated real low = 20.0 + (18.0 - 16.0) = 22.0
+    # Calculated real high = 20.0 + (24.0 - 16.0) = 28.0
+    await proxy._async_realign_real_target_from_sensor()
+
+    assert mock_hass.services.async_call.called
+    args, kwargs = mock_hass.services.async_call.call_args
+    assert args[0] == "climate"
+    assert args[1] == "set_temperature"
+    assert args[2]["target_temp_low"] == 22.0
+    assert args[2]["target_temp_high"] == 28.0
+
+
+@pytest.mark.asyncio
+async def test_dual_setpoint_overdrive_heat(mock_hass):
+    """Test heat overdrive in dual setpoint mode when remote is cold and system is idle."""
+    proxy = create_dual_proxy(mock_hass)
+
+    # Thermostat is idle, current = 20.0, low = 18.0, high = 24.0
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.HEAT_COOL,
+        {
+            "current_temperature": 20.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
+            "hvac_action": HVACAction.IDLE,
+            "target_temp_step": 1.0,
+            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        },
+    )
+
+    # Remote sensor is 16.0, virtual low = 18.0 (wants heat!)
+    # Standard calculated real low = 20.0 + (18.0 - 16.0) = 22.0
+    # Plus heat overdrive (+1.0) = 23.0
+    proxy._sensor_states["sensor.remote"] = State("sensor.remote", "16.0")
+
+    await proxy._async_realign_real_target_from_sensor()
+
+    assert mock_hass.services.async_call.called
+    args, kwargs = mock_hass.services.async_call.call_args
+    assert args[0] == "climate"
+    assert args[1] == "set_temperature"
+    assert args[2]["target_temp_low"] == 23.0
+
+
+@pytest.mark.asyncio
+async def test_dual_setpoint_overdrive_cool(mock_hass):
+    """Test cool overdrive in dual setpoint mode when remote is hot and system is idle."""
+    proxy = create_dual_proxy(mock_hass)
+
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.HEAT_COOL,
+        {
+            "current_temperature": 20.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
+            "hvac_action": HVACAction.IDLE,
+            "target_temp_step": 1.0,
+            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        },
+    )
+
+    # Remote sensor is 26.0, virtual high = 24.0 (wants cooling!)
+    # Standard calculated real high = 20.0 + (24.0 - 26.0) = 18.0
+    # Plus cool overdrive (-1.0) = 17.0
+    proxy._sensor_states["sensor.remote"] = State("sensor.remote", "26.0")
+
+    await proxy._async_realign_real_target_from_sensor()
+
+    assert mock_hass.services.async_call.called
+    args, kwargs = mock_hass.services.async_call.call_args
+    assert args[0] == "climate"
+    assert args[1] == "set_temperature"
+    assert args[2]["target_temp_high"] == 17.0
+
+
+@pytest.mark.asyncio
+async def test_dual_setpoint_partial_set_temperature(mock_hass):
+    """Test setting only low or high temperature in dual setpoint mode."""
+    proxy = create_dual_proxy(mock_hass)
+
+    # Only setting low
+    await proxy.async_set_temperature(target_temp_low=19.0)
+
+    assert mock_hass.services.async_call.called
+    args, kwargs = mock_hass.services.async_call.call_args
+    assert args[0] == "climate"
+    assert args[1] == "set_temperature"
+    assert args[2]["target_temp_low"] == 21.0
+    assert "target_temp_high" not in args[2]
+    assert proxy.target_temperature_low == 19.0
+
+
+@pytest.mark.asyncio
+async def test_dual_setpoint_service_error_handling(mock_hass):
+    """Test error handling during dual setpoint realignment."""
+    proxy = create_dual_proxy(mock_hass)
+
+    proxy._sensor_states["sensor.remote"] = State("sensor.remote", "16.0")
+
+    async def side_effect(domain, service, service_data, blocking=False):
+        if domain == "climate":
+            raise Exception("502 Bad Gateway")
+
+    mock_hass.services.async_call.side_effect = side_effect
+
+    # Should handle error gracefully without raising
+    await proxy._async_realign_real_target_from_sensor()

--- a/tests/components/thermostat_proxy/test_external_change.py
+++ b/tests/components/thermostat_proxy/test_external_change.py
@@ -1,4 +1,5 @@
 """Tests for the disable_auto_switch configuration."""
+
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
@@ -21,7 +22,7 @@ def mock_hass():
     return hass
 
 
-def create_proxy(hass, disable_auto_switch=False):
+def create_proxy(hass, disable_auto_switch=False, hvac_mode=HVACMode.HEAT):
     """Helper to create a configured CustomThermostatEntity."""
     proxy = CustomThermostatEntity(
         hass=hass,
@@ -34,61 +35,77 @@ def create_proxy(hass, disable_auto_switch=False):
         use_last_active_sensor=False,
         disable_auto_switch=disable_auto_switch,
     )
-    
-    # Mock physical thermostat state
+
+    supported = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.PRESET_MODE
+    )
+
     mock_real_state = State(
         "climate.real",
-        HVACMode.HEAT,
+        hvac_mode,
         {
             "current_temperature": 20.0,
             "temperature": 22.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
             "target_temp_step": 1.0,
-            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+            "supported_features": supported,
+        },
     )
-    hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == "climate.real" else None
+    hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == "climate.real" else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
-    
+
     proxy._temperature_unit = "°C"
     proxy._sensor_states["sensor.remote"] = State("sensor.remote", "24.0")
     proxy._virtual_target_temperature = 26.0
+    proxy._virtual_target_temperature_low = 18.0
+    proxy._virtual_target_temperature_high = 24.0
     proxy._selected_sensor_name = "Remote"
     proxy._last_real_target_temp = 22.0
+    proxy._last_real_target_temp_low = 18.0
+    proxy._last_real_target_temp_high = 24.0
     proxy.async_write_ha_state = MagicMock()
     return proxy
 
 
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_auto_switch_enabled(mock_hass):
-    """Test that proxy switches to physical sensor when external change is detected (default)."""
-    proxy = create_proxy(mock_hass, disable_auto_switch=False)
-    
-    # Simulate an external change (real target changes to 23.0, previous was 22.0)
-    proxy._handle_external_real_target_change(23.0, 22.0)
-    
-    # Should switch to the physical sensor
-    assert proxy._selected_sensor_name == "Physical"
-    # Virtual target should become the real target
-    assert proxy._virtual_target_temperature == 23.0
+async def test_auto_switch_enabled(mock_hass, hvac_mode):
+    """Test that proxy switches to physical sensor when external change is detected in all modes."""
+    proxy = create_proxy(mock_hass, disable_auto_switch=False, hvac_mode=hvac_mode)
+
+    if hvac_mode in (HVACMode.HEAT_COOL, HVACMode.AUTO):
+        proxy._detect_external_dual_target_change(19.0, 24.0, was_not_controlling=False)
+        assert proxy._selected_sensor_name == "Physical"
+        assert proxy._virtual_target_temperature_low == 19.0
+    else:
+        proxy._handle_external_real_target_change(23.0, 22.0)
+        assert proxy._selected_sensor_name == "Physical"
+        assert proxy._virtual_target_temperature == 23.0
 
 
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_auto_switch_disabled(mock_hass):
-    """Test that proxy maintains sensor and updates virtual target when auto-switch is disabled."""
-    proxy = create_proxy(mock_hass, disable_auto_switch=True)
-    
-    # Current state: 
-    # Sensor temp = 24.0
-    # Real current = 20.0
-    # Virtual target = 26.0
-    # Real target was = 22.0
-    
-    # Simulate an external change (real target changes to 24.0, previous was 22.0)
-    proxy._handle_external_real_target_change(24.0, 22.0)
-    
-    # Should NOT switch to the physical sensor
-    assert proxy._selected_sensor_name == "Remote"
-    
-    # Virtual target should be updated by the delta: 26.0 + (24.0 - 22.0) = 28.0
-    assert proxy._virtual_target_temperature == 28.0
+async def test_auto_switch_disabled(mock_hass, hvac_mode):
+    """Test that proxy maintains sensor and updates virtual targets when auto-switch is disabled across all modes."""
+    proxy = create_proxy(mock_hass, disable_auto_switch=True, hvac_mode=hvac_mode)
+
+    if hvac_mode in (HVACMode.HEAT_COOL, HVACMode.AUTO):
+        proxy._detect_external_dual_target_change(20.0, 24.0, was_not_controlling=False)
+        assert proxy._selected_sensor_name == "Remote"
+        # Real low changed +2.0 (18.0 -> 20.0), virtual low 18.0 + 2.0 = 20.0
+        assert proxy._virtual_target_temperature_low == 20.0
+    else:
+        proxy._handle_external_real_target_change(24.0, 22.0)
+        assert proxy._selected_sensor_name == "Remote"
+        # Virtual target updated by delta: 26.0 + (24.0 - 22.0) = 28.0
+        assert proxy._virtual_target_temperature == 28.0

--- a/tests/components/thermostat_proxy/test_fallback.py
+++ b/tests/components/thermostat_proxy/test_fallback.py
@@ -1,4 +1,5 @@
 """Tests for the Thermostat Proxy fallback behavior."""
+
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
@@ -7,6 +8,7 @@ from homeassistant.components.climate import HVACMode, ClimateEntityFeature
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from custom_components.thermostat_proxy.climate import CustomThermostatEntity
+
 
 @pytest.fixture
 def mock_hass():
@@ -20,7 +22,8 @@ def mock_hass():
     hass.async_create_task.side_effect = lambda coro: coro.close()
     return hass
 
-def create_proxy(hass, thermostat="climate.real"):
+
+def create_proxy(hass, thermostat="climate.real", hvac_mode=HVACMode.HEAT):
     """Helper to create a configured CustomThermostatEntity."""
     proxy = CustomThermostatEntity(
         hass=hass,
@@ -32,48 +35,67 @@ def create_proxy(hass, thermostat="climate.real"):
         physical_sensor_name="Physical",
         use_last_active_sensor=False,
     )
-    
+
+    supported = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.PRESET_MODE
+    )
+
     mock_real_state = State(
         thermostat,
-        HVACMode.HEAT,
+        hvac_mode,
         {
             "current_temperature": 22.0,
             "temperature": 22.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
             "target_temp_step": 1.0,
-            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+            "supported_features": supported,
+        },
     )
-    hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == thermostat else None
+    hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == thermostat else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
     proxy._temperature_unit = "°C"
     proxy._virtual_target_temperature = 22.0
+    proxy._virtual_target_temperature_low = 18.0
+    proxy._virtual_target_temperature_high = 24.0
     proxy._selected_sensor_name = "Remote"
     proxy._sensor_states["sensor.remote"] = State("sensor.remote", "20.0")
     return proxy
 
+
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_remote_sensor_unavailable(mock_hass):
-    """Test fallback when remote sensor is unavailable."""
-    proxy = create_proxy(mock_hass)
-    
+async def test_remote_sensor_unavailable(mock_hass, hvac_mode):
+    """Test fallback when remote sensor is unavailable across all modes."""
+    proxy = create_proxy(mock_hass, hvac_mode=hvac_mode)
+
     # Normally, current temp is 20 (remote)
     assert proxy.current_temperature == 20.0
-    
+
     proxy._sensor_states["sensor.remote"] = State("sensor.remote", STATE_UNAVAILABLE)
-    
+
     # Fallback to physical (22.0)
     assert proxy.current_temperature == 22.0
 
+
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_remote_sensor_unknown(mock_hass):
-    """Test fallback when remote sensor is unknown."""
-    proxy = create_proxy(mock_hass)
-    
+async def test_remote_sensor_unknown(mock_hass, hvac_mode):
+    """Test fallback when remote sensor is unknown across all modes."""
+    proxy = create_proxy(mock_hass, hvac_mode=hvac_mode)
+
     assert proxy.current_temperature == 20.0
-    
+
     proxy._sensor_states["sensor.remote"] = State("sensor.remote", STATE_UNKNOWN)
-    
+
     # Fallback to physical (22.0)
     assert proxy.current_temperature == 22.0
-

--- a/tests/components/thermostat_proxy/test_issues.py
+++ b/tests/components/thermostat_proxy/test_issues.py
@@ -1,6 +1,7 @@
 """Tests simulating scenarios in GitHub issues #31 and #32."""
+
 import time
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 import pytest
 
 from homeassistant.core import HomeAssistant, State
@@ -18,15 +19,16 @@ def mock_hass():
     hass.config = MagicMock()
     hass.config.units.temperature_unit = "°C"
     hass.services = MagicMock()
-    hass.async_create_task = MagicMock(
-        side_effect=lambda coro, *a, **kw: coro.close()
-    )
+    hass.async_create_task = MagicMock(side_effect=lambda coro, *a, **kw: coro.close())
     return hass
 
 
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_issue_31_decimal_current_temperature(mock_hass):
-    """Test that a remote sensor with decimals displays decimals for current temperature."""
+async def test_issue_31_decimal_current_temperature(mock_hass, hvac_mode):
+    """Test that a remote sensor with decimals displays decimals for current temperature across all modes."""
     proxy = CustomThermostatEntity(
         hass=mock_hass,
         name="Test Proxy",
@@ -40,15 +42,22 @@ async def test_issue_31_decimal_current_temperature(mock_hass):
 
     mock_real_state = State(
         "climate.real",
-        HVACMode.HEAT,
+        hvac_mode,
         {
             "current_temperature": 20.0,
             "temperature": 22.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
             "target_temp_step": 1.0,
-            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            ),
+        },
     )
-    mock_hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == "climate.real" else None
+    mock_hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == "climate.real" else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
 
@@ -62,9 +71,12 @@ async def test_issue_31_decimal_current_temperature(mock_hass):
     assert proxy.precision == 0.1
 
 
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_issue_32_floor_rounding_thermostat_loop(mock_hass):
-    """Test that a floor-rounding physical thermostat reporting a floored target outside post-write grace period triggers external change detection."""
+async def test_issue_32_floor_rounding_thermostat_loop(mock_hass, hvac_mode):
+    """Test floor-rounding external change suppression across all HVAC modes."""
     proxy = CustomThermostatEntity(
         hass=mock_hass,
         name="Test Proxy",
@@ -81,15 +93,22 @@ async def test_issue_32_floor_rounding_thermostat_loop(mock_hass):
     # The proxy is operating in Fahrenheit, target_temp_step = 1.8 (Fahrenheit)
     mock_real_state = State(
         "climate.real",
-        HVACMode.HEAT,
+        hvac_mode,
         {
             "current_temperature": 75.0,
             "temperature": 73.4,  # floored Celsius value 23.0°C converted to Fahrenheit
+            "target_temp_low": 68.0,
+            "target_temp_high": 75.0,
             "target_temp_step": 1.8,
-            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            ),
+        },
     )
-    mock_hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == "climate.real" else None
+    mock_hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == "climate.real" else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
 
@@ -114,24 +133,30 @@ async def test_issue_32_floor_rounding_thermostat_loop(mock_hass):
     event.data = {
         "old_state": State(
             "climate.real",
-            HVACMode.HEAT,
+            hvac_mode,
             {
                 "current_temperature": 75.0,
                 "temperature": 74.5,
                 "target_temp_step": 1.8,
-                "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-            }
+                "supported_features": (
+                    ClimateEntityFeature.TARGET_TEMPERATURE
+                    | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+                ),
+            },
         ),
         "new_state": State(
             "climate.real",
-            HVACMode.HEAT,
+            hvac_mode,
             {
                 "current_temperature": 75.0,
                 "temperature": 73.4,
                 "target_temp_step": 1.8,
-                "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-            }
-        )
+                "supported_features": (
+                    ClimateEntityFeature.TARGET_TEMPERATURE
+                    | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+                ),
+            },
+        ),
     }
     proxy._async_handle_real_state_event(event)
 

--- a/tests/components/thermostat_proxy/test_modes.py
+++ b/tests/components/thermostat_proxy/test_modes.py
@@ -1,24 +1,27 @@
 """Tests for the Thermostat Proxy mode and overdrive logic."""
+
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant, State, CoreState
 from homeassistant.components.climate import HVACMode, ClimateEntityFeature
-from homeassistant.const import ATTR_TEMPERATURE
 
 from custom_components.thermostat_proxy.climate import CustomThermostatEntity
-from custom_components.thermostat_proxy.const import OVERDRIVE_ADJUSTMENT_HEAT, OVERDRIVE_ADJUSTMENT_COOL
+
 
 @pytest.fixture
 def mock_hass():
     """Mock Home Assistant instance."""
     hass = MagicMock(spec=HomeAssistant)
+    hass.state = CoreState.running
+    hass.data = {}
     hass.states = MagicMock()
     hass.config = MagicMock()
     hass.config.units.temperature_unit = "°C"
     hass.services = AsyncMock()
     hass.async_create_task.side_effect = lambda coro: coro.close()
     return hass
+
 
 def create_proxy(hass, thermostat="climate.real"):
     """Helper to create a configured CustomThermostatEntity."""
@@ -32,7 +35,7 @@ def create_proxy(hass, thermostat="climate.real"):
         physical_sensor_name="Physical",
         use_last_active_sensor=False,
     )
-    
+
     mock_real_state = State(
         thermostat,
         HVACMode.HEAT,
@@ -41,65 +44,226 @@ def create_proxy(hass, thermostat="climate.real"):
             "temperature": 22.0,
             "target_temp_step": 1.0,
             "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+        },
     )
-    hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == thermostat else None
+    hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == thermostat else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
     proxy._temperature_unit = "°C"
     proxy._sensor_states["sensor.remote"] = State("sensor.remote", "20.0")
     proxy._virtual_target_temperature = 22.0
     proxy._selected_sensor_name = "Remote"
+    proxy.async_write_ha_state = MagicMock()
     return proxy
+
 
 @pytest.mark.asyncio
 async def test_overdrive_heat(mock_hass):
     """Test that heat overdrive is applied when physical thermostat is satisfied but remote is cold."""
     proxy = create_proxy(mock_hass)
-    
-    proxy._real_state = State("climate.real", HVACMode.HEAT, {
-        "current_temperature": 24.0,
-        "temperature": 24.0, # Physical is satisfied
-        "hvac_action": "idle",
-        "target_temp_step": 1.0,
-        "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-    })
-    
+
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.HEAT,
+        {
+            "current_temperature": 24.0,
+            "temperature": 24.0,  # Physical is satisfied
+            "hvac_action": "idle",
+            "target_temp_step": 1.0,
+            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
+        },
+    )
+
     # Virtual target = 22.0, remote = 20.0. Diff is +2.0.
     # Calculated target = 24.0 + 2.0 = 26.0.
     # Plus overdrive (1.0) = 27.0.
-    
+
     await proxy._async_realign_real_target_from_sensor()
-    
+
     # Verify service call
     assert mock_hass.services.async_call.called
     args, kwargs = mock_hass.services.async_call.call_args
     assert args[0] == "climate"
     assert args[1] == "set_temperature"
     assert args[2]["temperature"] == 27.0
-    
+
+
 @pytest.mark.asyncio
 async def test_overdrive_cool(mock_hass):
     """Test that cool overdrive is applied when physical thermostat is satisfied but remote is hot."""
     proxy = create_proxy(mock_hass)
-    proxy._real_state = State("climate.real", HVACMode.COOL, {
-        "current_temperature": 20.0,
-        "temperature": 20.0,
-        "hvac_action": "idle",
-        "target_temp_step": 1.0,
-        "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-    })
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.COOL,
+        {
+            "current_temperature": 20.0,
+            "temperature": 20.0,
+            "hvac_action": "idle",
+            "target_temp_step": 1.0,
+            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
+        },
+    )
     proxy._virtual_target_temperature = 20.0
     proxy._sensor_states["sensor.remote"] = State("sensor.remote", "22.0")
-    
+
     # Virtual target = 20.0, remote = 22.0. Diff is -2.0.
     # Calculated target = 20.0 - 2.0 = 18.0.
     # Plus overdrive (-1.0) = 17.0.
-    
+
     await proxy._async_realign_real_target_from_sensor()
-    
+
     assert mock_hass.services.async_call.called
     args, kwargs = mock_hass.services.async_call.call_args
     assert args[0] == "climate"
     assert args[1] == "set_temperature"
     assert args[2]["temperature"] == 17.0
+
+
+@pytest.mark.asyncio
+async def test_cool_mode_target_temperature_on_range_capable_thermostat(mock_hass):
+    """Test that COOL mode presents single target_temperature on a dual-setpoint capable thermostat."""
+    proxy = create_proxy(mock_hass)
+
+    # Real thermostat supports dual setpoints but is currently in COOL mode
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.COOL,
+        {
+            "current_temperature": 24.0,
+            "temperature": 24.0,
+            "target_temp_low": 20.0,
+            "target_temp_high": 26.0,
+            "target_temp_step": 1.0,
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+                | ClimateEntityFeature.PRESET_MODE
+            ),
+        },
+    )
+    proxy._update_real_temperature_limits()
+    proxy._virtual_target_temperature = 22.0
+    proxy._virtual_target_temperature_low = 20.0
+    proxy._virtual_target_temperature_high = 26.0
+
+    # In COOL mode, entity must report single target_temperature and None for low/high
+    assert not proxy.is_range_mode
+    assert proxy.target_temperature == 22.0
+    assert proxy.target_temperature_low is None
+    assert proxy.target_temperature_high is None
+
+    # Setting target in COOL mode
+    await proxy.async_set_temperature(temperature=21.0)
+
+    assert mock_hass.services.async_call.called
+    args, kwargs = mock_hass.services.async_call.call_args
+    assert args[0] == "climate"
+    assert args[1] == "set_temperature"
+    assert args[2]["temperature"] == 25.0  # Real target = 24.0 + (21.0 - 20.0) = 25.0
+    assert proxy.target_temperature == 21.0
+
+
+@pytest.mark.asyncio
+async def test_heat_mode_target_temperature_on_range_capable_thermostat(mock_hass):
+    """Test that HEAT mode presents single target_temperature on a dual-setpoint capable thermostat."""
+    proxy = create_proxy(mock_hass)
+
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.HEAT,
+        {
+            "current_temperature": 20.0,
+            "temperature": 20.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
+            "target_temp_step": 1.0,
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            ),
+        },
+    )
+    proxy._update_real_temperature_limits()
+    proxy._virtual_target_temperature = 21.0
+    proxy._virtual_target_temperature_low = 18.0
+    proxy._virtual_target_temperature_high = 24.0
+
+    assert not proxy.is_range_mode
+    assert proxy.target_temperature == 21.0
+    assert proxy.target_temperature_low is None
+    assert proxy.target_temperature_high is None
+
+
+@pytest.mark.asyncio
+async def test_heat_cool_mode_target_temperatures(mock_hass):
+    """Test that HEAT_COOL mode presents range targets and None for single target_temperature."""
+    proxy = create_proxy(mock_hass)
+
+    proxy._real_state = State(
+        "climate.real",
+        HVACMode.HEAT_COOL,
+        {
+            "current_temperature": 22.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
+            "target_temp_step": 1.0,
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            ),
+        },
+    )
+    proxy._update_real_temperature_limits()
+    proxy._virtual_target_temperature = 21.0
+    proxy._virtual_target_temperature_low = 18.0
+    proxy._virtual_target_temperature_high = 24.0
+
+    assert proxy.is_range_mode
+    assert proxy.target_temperature is None
+    assert proxy.target_temperature_low == 18.0
+    assert proxy.target_temperature_high == 24.0
+
+
+@pytest.mark.asyncio
+async def test_mode_transition_target_sync(mock_hass):
+    """Test that switching from HEAT_COOL to COOL adopts high setpoint and from HEAT_COOL to HEAT adopts low setpoint."""
+    proxy = create_proxy(mock_hass)
+
+    # Initial state: HEAT_COOL mode with low=18.0, high=24.0, stale virtual_target=15.0
+    old_state = State("climate.real", HVACMode.HEAT_COOL, {"temperature": None})
+    new_state = State("climate.real", HVACMode.COOL, {"temperature": 24.0})
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+
+    proxy._virtual_target_temperature = 15.0  # stale value
+    proxy._virtual_target_temperature_low = 18.0
+    proxy._virtual_target_temperature_high = 24.0
+
+    proxy._async_handle_real_state_event(event)
+
+    # Switching to COOL must adopt high target (24.0), not stale target (15.0)
+    assert proxy._virtual_target_temperature == 24.0
+
+
+@pytest.mark.asyncio
+async def test_mode_change_suppresses_external_target_change(mock_hass):
+    """Test that a mode change on the physical thermostat does not trigger false external change detection."""
+    proxy = create_proxy(mock_hass)
+
+    proxy._selected_sensor_name = "Remote"
+    proxy._last_real_target_temp = 22.0  # target in HEAT mode
+
+    # Real thermostat transitions from HEAT (22.0) to COOL (18.0)
+    old_state = State("climate.real", HVACMode.HEAT, {"temperature": 22.0})
+    new_state = State("climate.real", HVACMode.COOL, {"temperature": 18.0})
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+
+    proxy._async_handle_real_state_event(event)
+
+    # Should NOT switch preset to Physical due to false external change
+    assert proxy._selected_sensor_name == "Remote"
+    # Last real target updated to new mode's setpoint (18.0)
+    assert proxy._last_real_target_temp == 18.0

--- a/tests/components/thermostat_proxy/test_restore_state.py
+++ b/tests/components/thermostat_proxy/test_restore_state.py
@@ -1,4 +1,5 @@
 """Tests for the Thermostat Proxy state restoration."""
+
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
@@ -6,6 +7,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.components.climate import HVACMode, ClimateEntityFeature
 
 from custom_components.thermostat_proxy.climate import CustomThermostatEntity
+
 
 @pytest.fixture
 def mock_hass():
@@ -17,7 +19,8 @@ def mock_hass():
     hass.services = AsyncMock()
     return hass
 
-def create_proxy(hass, thermostat="climate.real"):
+
+def create_proxy(hass, thermostat="climate.real", hvac_mode=HVACMode.HEAT):
     """Helper to create a configured CustomThermostatEntity."""
     proxy = CustomThermostatEntity(
         hass=hass,
@@ -29,39 +32,63 @@ def create_proxy(hass, thermostat="climate.real"):
         physical_sensor_name="Physical",
         use_last_active_sensor=False,
     )
-    
+
+    supported = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.PRESET_MODE
+    )
+
     mock_real_state = State(
         thermostat,
-        HVACMode.HEAT,
+        hvac_mode,
         {
             "current_temperature": 22.0,
             "temperature": 22.0,
+            "target_temp_low": 18.0,
+            "target_temp_high": 24.0,
             "target_temp_step": 1.0,
-            "supported_features": ClimateEntityFeature.TARGET_TEMPERATURE,
-        }
+            "supported_features": supported,
+        },
     )
-    hass.states.get.side_effect = lambda entity_id: mock_real_state if entity_id == thermostat else None
+    hass.states.get.side_effect = lambda entity_id: (
+        mock_real_state if entity_id == thermostat else None
+    )
     proxy._real_state = mock_real_state
     proxy._update_real_temperature_limits()
     proxy._temperature_unit = "°C"
     return proxy
 
+
+@pytest.mark.parametrize(
+    "hvac_mode", [HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL, HVACMode.AUTO]
+)
 @pytest.mark.asyncio
-async def test_state_restoration(mock_hass):
-    """Test restoring state on startup."""
-    proxy = create_proxy(mock_hass)
-    
+async def test_state_restoration(mock_hass, hvac_mode):
+    """Test restoring state on startup across all modes."""
+    proxy = create_proxy(mock_hass, hvac_mode=hvac_mode)
+
     # Mock the restore state methods
-    proxy.async_get_last_state = AsyncMock(return_value=State("climate.proxy", HVACMode.HEAT, {
-        "temperature": 24.0,
-        "preset_mode": "Remote",
-    }))
-    
+    proxy.async_get_last_state = AsyncMock(
+        return_value=State(
+            "climate.proxy",
+            hvac_mode,
+            {
+                "temperature": 24.0,
+                "target_temp_low": 19.0,
+                "target_temp_high": 25.0,
+                "preset_mode": "Remote",
+            },
+        )
+    )
+
     proxy._context = MagicMock()
     proxy._async_write_ha_state = MagicMock()
     proxy._schedule_target_realign = MagicMock()
-    
+
     await proxy._async_restore_state()
-    
+
     assert proxy._virtual_target_temperature == 24.0
+    assert proxy._virtual_target_temperature_low == 19.0
+    assert proxy._virtual_target_temperature_high == 25.0
     assert proxy._selected_sensor_name == "Remote"

--- a/tests/components/thermostat_proxy/test_setup.py
+++ b/tests/components/thermostat_proxy/test_setup.py
@@ -1,4 +1,5 @@
 """Tests for integration setup and wiring."""
+
 from unittest.mock import patch
 import pytest
 
@@ -17,6 +18,7 @@ from custom_components.thermostat_proxy.const import (
 def mock_services(hass: HomeAssistant):
     """Mock service calls to avoid ServiceNotFound errors, but allow custom calls."""
     from homeassistant.core import ServiceRegistry
+
     real_async_call = ServiceRegistry.async_call
 
     async def mock_call(
@@ -28,9 +30,10 @@ def mock_services(hass: HomeAssistant):
         target=None,
     ):
         entity_id = (service_data or {}).get("entity_id")
-        if domain == "climate" and (entity_id == "climate.thermostat_proxy" or (
-            isinstance(entity_id, list) and "climate.thermostat_proxy" in entity_id
-        )):
+        if domain == "climate" and (
+            entity_id == "climate.thermostat_proxy"
+            or (isinstance(entity_id, list) and "climate.thermostat_proxy" in entity_id)
+        ):
             return await real_async_call(
                 hass.services, domain, service, service_data, blocking, context, target
             )
@@ -73,18 +76,19 @@ async def test_async_setup_entry_wiring(hass: HomeAssistant) -> None:
         assert getattr(entity, "_disable_auto_switch", False) is True
 
 
+@pytest.mark.parametrize("mode", ["heat", "cool"])
 @pytest.mark.asyncio
-async def test_external_change_real_flow(hass: HomeAssistant) -> None:
-    """Test that a 1-degree change on the physical thermostat is correctly detected and shifts the proxy target by 1 degree."""
+async def test_external_change_real_flow(hass: HomeAssistant, mode: str) -> None:
+    """Test that a 1-degree change on the physical thermostat is correctly detected and shifts the proxy target by 1 degree across single-target modes."""
     # First, mock the states in the state machine
     hass.states.async_set(
         "climate.real",
-        "heat",
+        mode,
         {
             "current_temperature": 20.0,
             "temperature": 22.0,
             "target_temp_step": 1.0,
-            "supported_features": 1, # TARGET_TEMPERATURE
+            "supported_features": 1,  # TARGET_TEMPERATURE
         },
     )
     hass.states.async_set("sensor.remote", "24.0")
@@ -100,7 +104,7 @@ async def test_external_change_real_flow(hass: HomeAssistant) -> None:
             CONF_DISABLE_AUTO_SWITCH: True,
         },
         source="user",
-        unique_id="proxy",
+        unique_id=f"proxy_{mode}",
     )
     entry.add_to_hass(hass)
 
@@ -131,7 +135,7 @@ async def test_external_change_real_flow(hass: HomeAssistant) -> None:
     # Simulate external change on real thermostat target: 22.0 -> 21.0 (-1.0 degree)
     hass.states.async_set(
         "climate.real",
-        "heat",
+        mode,
         {
             "current_temperature": 20.0,
             "temperature": 21.0,
@@ -144,4 +148,3 @@ async def test_external_change_real_flow(hass: HomeAssistant) -> None:
     # The virtual target should also decrease by 1 degree: 26.0 -> 25.0
     proxy_state = hass.states.get("climate.thermostat_proxy")
     assert proxy_state.attributes["temperature"] == 25.0
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,18 @@
 """Fixtures for the Thermostat Proxy tests."""
+
 import pytest
+
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations in Home Assistant tests."""
     yield
 
+
 @pytest.fixture(autouse=True)
 def mock_dependencies():
     """Mock required dependencies so they don't try to load."""
     from unittest.mock import patch
+
     with patch("homeassistant.setup.async_setup_component", return_value=True):
         yield


### PR DESCRIPTION
Resolves #27

## Summary
This pull request adds full support for dual setpoint modes (`HEAT_COOL` and `AUTO`) to `Thermostat Proxy` while maintaining active remote sensor temperature regulation.

## Key Changes
- **Dual Setpoint Regulation**: Extended `CustomThermostatEntity` to calculate and adjust high/low setpoints on the physical thermostat based on remote sensor temperature offsets.
- **Mode-Aware Target Properties**: Updated `target_temperature`, `target_temperature_low`, and `target_temperature_high` properties to evaluate `is_range_mode` based on the active `hvac_mode`. This fixes single-target UI controls in `COOL` and `HEAT` modes on dual-capable hardware.
- **Mode Transition Target Sync**: Automatically synchronizes virtual single-target temperature when switching between dual setpoint modes (`HEAT_COOL`/`AUTO`) and single-target modes (`COOL`/`HEAT`).
- **External Change Detection**: Suppresses false external change triggers during HVAC mode transitions so physical mode setpoint differences are captured cleanly.
- **Logbook Attribution**: Added logbook entries detailing dual setpoint adjustments and realignment reasonings.
- **Comprehensive Unit Testing**: Expanded pytest suite to 53 tests covering all HVAC modes (`HEAT`, `COOL`, `HEAT_COOL`, `AUTO`).

## Verification
- Static Analysis: `ruff` and `black` passed with zero errors.
- Unit Testing: 53/53 tests passed cleanly (`pytest tests/ -v`).