### PR TITLE
feat: add replace sensor functionality to config flow

### DIFF
--- a/custom_components/thermostat_proxy/config_flow.py
+++ b/custom_components/thermostat_proxy/config_flow.py
@@ -76,6 +76,7 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._max_sync_offset: float | None = None
         self._disable_auto_switch: bool = DEFAULT_DISABLE_AUTO_SWITCH
         self._reconfigure_entry: config_entries.ConfigEntry | None = None
+        self._replace_target: str | None = None
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         errors: dict[str, str] = {}
@@ -320,6 +321,41 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             target = user_input.get(CONF_TARGET_SENSOR)
+            if target not in options:
+                errors["base"] = "invalid_default_sensor"
+            else:
+                self._replace_target = target
+                return await self.async_step_replace_sensor_details()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_TARGET_SENSOR): selector.SelectSelector(
+                    selector.SelectSelectorConfig(options=options)
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="replace_sensor",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_replace_sensor_details(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        target = self._replace_target
+        if target is None:
+            return await self.async_step_replace_sensor()
+
+        target_sensor = next(
+            (s for s in self._sensors if s[CONF_SENSOR_NAME] == target), None
+        )
+        if target_sensor is None:
+            return await self.async_step_manage_sensors()
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
             sensor_name = user_input[CONF_SENSOR_NAME].strip()
             entity_id = user_input[CONF_SENSOR_ENTITY_ID]
 
@@ -327,9 +363,7 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 PHYSICAL_SENSOR_NAME.lower(),
                 self._physical_sensor_name.lower(),
             }
-            if target not in options:
-                errors["base"] = "invalid_default_sensor"
-            elif sensor_name.lower() in reserved_names:
+            if sensor_name.lower() in reserved_names:
                 errors["base"] = "reserved_sensor_name"
             elif any(
                 sensor_name == sensor[CONF_SENSOR_NAME]
@@ -344,24 +378,24 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ):
                 errors["base"] = "duplicate_sensor_entity"
             else:
-                for sensor in self._sensors:
-                    if sensor[CONF_SENSOR_NAME] == target:
-                        sensor[CONF_SENSOR_NAME] = sensor_name
-                        sensor[CONF_SENSOR_ENTITY_ID] = entity_id
-                        break
+                target_sensor[CONF_SENSOR_NAME] = sensor_name
+                target_sensor[CONF_SENSOR_ENTITY_ID] = entity_id
                 if self._default_sensor == target:
                     self._default_sensor = sensor_name
+                self._replace_target = None
                 return await self.async_step_manage_sensors()
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_TARGET_SENSOR): selector.SelectSelector(
-                    selector.SelectSelectorConfig(options=options)
-                ),
-                vol.Required(CONF_SENSOR_NAME): selector.TextSelector(
+                vol.Required(
+                    CONF_SENSOR_NAME, default=target_sensor[CONF_SENSOR_NAME]
+                ): selector.TextSelector(
                     selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
                 ),
-                vol.Required(CONF_SENSOR_ENTITY_ID): selector.EntitySelector(
+                vol.Required(
+                    CONF_SENSOR_ENTITY_ID,
+                    default=target_sensor[CONF_SENSOR_ENTITY_ID],
+                ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
                         domain=["sensor", "climate", "number"],
                         device_class="temperature",
@@ -371,7 +405,7 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_show_form(
-            step_id="replace_sensor",
+            step_id="replace_sensor_details",
             data_schema=data_schema,
             errors=errors,
         )

--- a/custom_components/thermostat_proxy/config_flow.py
+++ b/custom_components/thermostat_proxy/config_flow.py
@@ -39,12 +39,15 @@ SENSOR_STEP = "sensors"
 FINALIZE_STEP = "finalize"
 CONF_ADD_ANOTHER = "add_another"
 CONF_ACTION = "action"
+CONF_TARGET_SENSOR = "target_sensor"
 
 ACTION_ADD_SENSOR = "add_sensor"
+ACTION_REPLACE_SENSOR = "replace_sensor"
 ACTION_REMOVE_SENSOR = "remove_sensor"
 ACTION_FINISH = "finish"
 ACTION_LABELS = {
     ACTION_ADD_SENSOR: "Add a sensor",
+    ACTION_REPLACE_SENSOR: "Replace a sensor",
     ACTION_REMOVE_SENSOR: "Remove a sensor",
     ACTION_FINISH: "Continue",
 }
@@ -184,6 +187,11 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             action = user_input[CONF_ACTION]
             if action == ACTION_ADD_SENSOR:
                 return await self.async_step_sensors()
+            if action == ACTION_REPLACE_SENSOR:
+                if not self._sensors:
+                    errors["base"] = "no_sensors"
+                else:
+                    return await self.async_step_replace_sensor()
             if action == ACTION_REMOVE_SENSOR:
                 if not self._sensors:
                     errors["base"] = "no_sensors"
@@ -197,6 +205,7 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         action_options = {ACTION_ADD_SENSOR: ACTION_LABELS[ACTION_ADD_SENSOR]}
         if self._sensors:
+            action_options[ACTION_REPLACE_SENSOR] = ACTION_LABELS[ACTION_REPLACE_SENSOR]
             action_options[ACTION_REMOVE_SENSOR] = ACTION_LABELS[ACTION_REMOVE_SENSOR]
             action_options[ACTION_FINISH] = ACTION_LABELS[ACTION_FINISH]
 
@@ -299,6 +308,70 @@ class CustomThermostatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="remove_sensor",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_replace_sensor(self, user_input: dict[str, Any] | None = None):
+        if not self._sensors:
+            return await self.async_step_manage_sensors()
+
+        options = [sensor[CONF_SENSOR_NAME] for sensor in self._sensors]
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            target = user_input.get(CONF_TARGET_SENSOR)
+            sensor_name = user_input[CONF_SENSOR_NAME].strip()
+            entity_id = user_input[CONF_SENSOR_ENTITY_ID]
+
+            reserved_names = {
+                PHYSICAL_SENSOR_NAME.lower(),
+                self._physical_sensor_name.lower(),
+            }
+            if target not in options:
+                errors["base"] = "invalid_default_sensor"
+            elif sensor_name.lower() in reserved_names:
+                errors["base"] = "reserved_sensor_name"
+            elif any(
+                sensor_name == sensor[CONF_SENSOR_NAME]
+                for sensor in self._sensors
+                if sensor[CONF_SENSOR_NAME] != target
+            ):
+                errors["base"] = "duplicate_sensor_name"
+            elif any(
+                entity_id == sensor[CONF_SENSOR_ENTITY_ID]
+                for sensor in self._sensors
+                if sensor[CONF_SENSOR_NAME] != target
+            ):
+                errors["base"] = "duplicate_sensor_entity"
+            else:
+                for sensor in self._sensors:
+                    if sensor[CONF_SENSOR_NAME] == target:
+                        sensor[CONF_SENSOR_NAME] = sensor_name
+                        sensor[CONF_SENSOR_ENTITY_ID] = entity_id
+                        break
+                if self._default_sensor == target:
+                    self._default_sensor = sensor_name
+                return await self.async_step_manage_sensors()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_TARGET_SENSOR): selector.SelectSelector(
+                    selector.SelectSelectorConfig(options=options)
+                ),
+                vol.Required(CONF_SENSOR_NAME): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                ),
+                vol.Required(CONF_SENSOR_ENTITY_ID): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain=["sensor", "climate", "number"],
+                        device_class="temperature",
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="replace_sensor",
             data_schema=data_schema,
             errors=errors,
         )

--- a/custom_components/thermostat_proxy/strings.json
+++ b/custom_components/thermostat_proxy/strings.json
@@ -41,6 +41,15 @@
           "name": "Sensor name"
         }
       },
+      "replace_sensor": {
+        "title": "Replace a sensor",
+        "description": "Select a sensor to replace and specify its new name and entity.",
+        "data": {
+          "target_sensor": "Sensor to replace",
+          "name": "New sensor name",
+          "entity_id": "New temperature entity"
+        }
+      },
       "finalize": {
         "title": "Defaults",
         "description": "Optionally rename the physical thermostat preset and decide which sensor (including the last active one) should be active on startup.",

--- a/custom_components/thermostat_proxy/strings.json
+++ b/custom_components/thermostat_proxy/strings.json
@@ -43,11 +43,17 @@
       },
       "replace_sensor": {
         "title": "Replace a sensor",
-        "description": "Select a sensor to replace and specify its new name and entity.",
+        "description": "Select a sensor to replace.",
         "data": {
-          "target_sensor": "Sensor to replace",
-          "name": "New sensor name",
-          "entity_id": "New temperature entity"
+          "target_sensor": "Sensor to replace"
+        }
+      },
+      "replace_sensor_details": {
+        "title": "Replace a sensor",
+        "description": "Update the name and temperature entity for this sensor.",
+        "data": {
+          "name": "Sensor name",
+          "entity_id": "Temperature entity"
         }
       },
       "finalize": {

--- a/custom_components/thermostat_proxy/translations/en.json
+++ b/custom_components/thermostat_proxy/translations/en.json
@@ -41,6 +41,15 @@
           "name": "Sensor name"
         }
       },
+      "replace_sensor": {
+        "title": "Replace a sensor",
+        "description": "Select a sensor to replace and specify its new name and entity.",
+        "data": {
+          "target_sensor": "Sensor to replace",
+          "name": "New sensor name",
+          "entity_id": "New temperature entity"
+        }
+      },
       "finalize": {
         "title": "Defaults",
         "description": "Optionally rename the physical thermostat preset and decide which sensor (including the last active one) should be active on startup.",

--- a/custom_components/thermostat_proxy/translations/en.json
+++ b/custom_components/thermostat_proxy/translations/en.json
@@ -43,11 +43,17 @@
       },
       "replace_sensor": {
         "title": "Replace a sensor",
-        "description": "Select a sensor to replace and specify its new name and entity.",
+        "description": "Select a sensor to replace.",
         "data": {
-          "target_sensor": "Sensor to replace",
-          "name": "New sensor name",
-          "entity_id": "New temperature entity"
+          "target_sensor": "Sensor to replace"
+        }
+      },
+      "replace_sensor_details": {
+        "title": "Replace a sensor",
+        "description": "Update the name and temperature entity for this sensor.",
+        "data": {
+          "name": "Sensor name",
+          "entity_id": "Temperature entity"
         }
       },
       "finalize": {

--- a/tests/components/thermostat_proxy/test_config_flow.py
+++ b/tests/components/thermostat_proxy/test_config_flow.py
@@ -114,3 +114,67 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"]["cooldown_period"] == 1800
     assert result["data"]["default_sensor"] == "Remote"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_replace_sensor(hass: HomeAssistant) -> None:
+    """Test replacing a sensor in the config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Proxy", "thermostat": "climate.real"},
+    )
+
+    # Add a sensor
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"action": "add_sensor"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Remote", "entity_id": "sensor.remote", "add_another": False},
+    )
+    assert result["step_id"] == "manage_sensors"
+
+    # Replace sensor action
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"action": "replace_sensor"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "replace_sensor"
+
+    # Replace sensor with new name and entity
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "target_sensor": "Remote",
+            "name": "New Remote",
+            "entity_id": "sensor.new_remote",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "manage_sensors"
+
+    # Finish
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"action": "finish"},
+    )
+    assert result["step_id"] == "finalize"
+
+    # Finalize
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "cooldown_period": 1800,
+            "physical_sensor_name": "Physical",
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SENSORS][0]["name"] == "New Remote"
+    assert result["data"][CONF_SENSORS][0]["entity_id"] == "sensor.new_remote"
+

--- a/tests/components/thermostat_proxy/test_config_flow.py
+++ b/tests/components/thermostat_proxy/test_config_flow.py
@@ -138,7 +138,7 @@ async def test_user_flow_replace_sensor(hass: HomeAssistant) -> None:
     )
     assert result["step_id"] == "manage_sensors"
 
-    # Replace sensor action
+    # Replace sensor action — select target
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {"action": "replace_sensor"},
@@ -146,11 +146,18 @@ async def test_user_flow_replace_sensor(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "replace_sensor"
 
+    # Select which sensor to replace
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"target_sensor": "Remote"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "replace_sensor_details"
+
     # Replace sensor with new name and entity
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            "target_sensor": "Remote",
             "name": "New Remote",
             "entity_id": "sensor.new_remote",
         },
@@ -177,4 +184,64 @@ async def test_user_flow_replace_sensor(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_SENSORS][0]["name"] == "New Remote"
     assert result["data"][CONF_SENSORS][0]["entity_id"] == "sensor.new_remote"
+
+
+@pytest.mark.asyncio
+async def test_replace_sensor_keep_name(hass: HomeAssistant) -> None:
+    """Test replacing only the entity while keeping the pre-populated name."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Proxy", "thermostat": "climate.real"},
+    )
+
+    # Add a sensor
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"action": "add_sensor"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Remote", "entity_id": "sensor.remote", "add_another": False},
+    )
+
+    # Replace sensor — select target
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"action": "replace_sensor"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"target_sensor": "Remote"},
+    )
+    assert result["step_id"] == "replace_sensor_details"
+
+    # Submit with same name, different entity
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "name": "Remote",
+            "entity_id": "sensor.kitchen",
+        },
+    )
+    assert result["step_id"] == "manage_sensors"
+
+    # Finish
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"action": "finish"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "cooldown_period": 1800,
+            "physical_sensor_name": "Physical",
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SENSORS][0]["name"] == "Remote"
+    assert result["data"][CONF_SENSORS][0]["entity_id"] == "sensor.kitchen"
 


### PR DESCRIPTION
## Summary of Changes

Adds functionality to replace an existing temperature sensor directly within the integration configuration flow.

- **Config Flow Enhancements**:
  - Added a multi-step `replace_sensor` workflow within the `manage_sensors` menu allowing users to select an existing configured sensor and replace its entity ID or name without deleting and re-adding it.
  - Implemented pre-population of current sensor values in the `replace_sensor_details` form step.
  - Added localized UI strings for new steps in `strings.json` and `translations/en.json`.
- **Testing**:
  - Added full unit test coverage for replacing sensors in `test_config_flow.py`, including testing entity updates while keeping pre-populated sensor names.