### PR TITLE
Add swing mode passthrough and translations

### DIFF
--- a/custom_components/thermostat_proxy/climate.py
+++ b/custom_components/thermostat_proxy/climate.py
@@ -116,6 +116,10 @@ _RESERVED_REAL_ATTRIBUTES = {
     "supported_features",
     "fan_mode",
     "fan_modes",
+    "swing_mode",
+    "swing_modes",
+    "swing_horizontal_mode",
+    "swing_horizontal_modes",
     "target_temp_high",
     "target_temp_low",
     "current_humidity",
@@ -1417,6 +1421,32 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             blocking=True,
         )
 
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set the physical thermostat's vertical swing mode."""
+        await self.hass.services.async_call(
+            CLIMATE_DOMAIN,
+            "set_swing_mode",
+            {
+                ATTR_ENTITY_ID: self._real_entity_id,
+                "swing_mode": swing_mode,
+            },
+            blocking=True,
+        )
+
+    async def async_set_swing_horizontal_mode(
+        self, swing_horizontal_mode: str
+    ) -> None:
+        """Set the physical thermostat's horizontal swing mode."""
+        await self.hass.services.async_call(
+            CLIMATE_DOMAIN,
+            "set_swing_horizontal_mode",
+            {
+                ATTR_ENTITY_ID: self._real_entity_id,
+                "swing_horizontal_mode": swing_horizontal_mode,
+            },
+            blocking=True,
+        )
+
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         self._log_debug("async_set_preset_mode called with preset: %s", preset_mode)
         if preset_mode not in self._sensor_lookup:
@@ -2197,6 +2227,10 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
 
         if supported & ClimateEntityFeature.FAN_MODE:
             base_features |= ClimateEntityFeature.FAN_MODE
+        if supported & ClimateEntityFeature.SWING_MODE:
+            base_features |= ClimateEntityFeature.SWING_MODE
+        if supported & ClimateEntityFeature.SWING_HORIZONTAL_MODE:
+            base_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
         self._attr_supported_features = base_features
 
     def _update_sensor_health_from_state(
@@ -2594,6 +2628,34 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         """Return the list of available fan modes."""
         if self._real_state:
             return self._real_state.attributes.get("fan_modes")
+        return None
+
+    @property
+    def swing_mode(self) -> str | None:
+        """Return the physical thermostat's vertical swing setting."""
+        if self._real_state:
+            return self._real_state.attributes.get("swing_mode")
+        return None
+
+    @property
+    def swing_modes(self) -> list[str] | None:
+        """Return the physical thermostat's vertical swing modes."""
+        if self._real_state:
+            return self._real_state.attributes.get("swing_modes")
+        return None
+
+    @property
+    def swing_horizontal_mode(self) -> str | None:
+        """Return the physical thermostat's horizontal swing setting."""
+        if self._real_state:
+            return self._real_state.attributes.get("swing_horizontal_mode")
+        return None
+
+    @property
+    def swing_horizontal_modes(self) -> list[str] | None:
+        """Return the physical thermostat's horizontal swing modes."""
+        if self._real_state:
+            return self._real_state.attributes.get("swing_horizontal_modes")
         return None
 
 

--- a/custom_components/thermostat_proxy/climate.py
+++ b/custom_components/thermostat_proxy/climate.py
@@ -2632,6 +2632,8 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
 
     @property
     def swing_mode(self) -> str | None:
+        # Daikin Onecta labels reference:
+        # https://github.com/jwillemsen/daikin_onecta
         """Return the physical thermostat's vertical swing setting."""
         if self._real_state:
             return self._real_state.attributes.get("swing_mode")

--- a/custom_components/thermostat_proxy/strings.json
+++ b/custom_components/thermostat_proxy/strings.json
@@ -1,5 +1,25 @@
 {
   "title": "Thermostat Proxy",
+  "entity_component": {
+    "climate": {
+      "state_attributes": {
+        "swing_mode": {
+          "state": {
+            "stop": "Stop",
+            "swing": "Swing",
+            "floorheatingairflow": "FloorHeating Airflow",
+            "windnice": "Comfort Airflow"
+          }
+        },
+        "swing_horizontal_mode": {
+          "state": {
+            "stop": "Stop",
+            "swing": "Swing"
+          }
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/thermostat_proxy/translations/en.json
+++ b/custom_components/thermostat_proxy/translations/en.json
@@ -1,5 +1,25 @@
 {
   "title": "Thermostat Proxy",
+  "entity_component": {
+    "climate": {
+      "state_attributes": {
+        "swing_mode": {
+          "state": {
+            "stop": "Stop",
+            "swing": "Swing",
+            "floorheatingairflow": "FloorHeating Airflow",
+            "windnice": "Comfort Airflow"
+          }
+        },
+        "swing_horizontal_mode": {
+          "state": {
+            "stop": "Stop",
+            "swing": "Swing"
+          }
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/tests/components/thermostat_proxy/test_swing.py
+++ b/tests/components/thermostat_proxy/test_swing.py
@@ -1,0 +1,108 @@
+"""Tests for swing passthrough."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.components.climate import ClimateEntityFeature, HVACMode
+from homeassistant.core import CoreState, HomeAssistant, State
+
+from custom_components.thermostat_proxy.climate import CustomThermostatEntity
+
+
+@pytest.fixture
+def mock_hass():
+    """Return a minimal Home Assistant mock."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.state = CoreState.running
+    hass.data = {}
+    hass.states = MagicMock()
+    hass.config = MagicMock()
+    hass.config.units.temperature_unit = "°C"
+    hass.services = AsyncMock()
+    hass.async_create_task.side_effect = lambda coro: coro.close()
+    return hass
+
+
+def create_proxy(hass):
+    """Return a proxy wrapping a swing-capable climate entity."""
+    physical = State(
+        "climate.real",
+        HVACMode.COOL,
+        {
+            "current_temperature": 24.0,
+            "temperature": 23.0,
+            "target_temp_step": 0.5,
+            "supported_features": (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                | ClimateEntityFeature.SWING_MODE
+                | ClimateEntityFeature.SWING_HORIZONTAL_MODE
+            ),
+            "swing_mode": "stop",
+            "swing_modes": ["stop", "swing"],
+            "swing_horizontal_mode": "stop",
+            "swing_horizontal_modes": ["stop", "swing"],
+        },
+    )
+    hass.states.get.side_effect = lambda entity_id: (
+        physical if entity_id == "climate.real" else None
+    )
+    proxy = CustomThermostatEntity(
+        hass=hass,
+        name="Test Proxy",
+        real_thermostat="climate.real",
+        sensors=[{"name": "Remote", "entity_id": "sensor.remote"}],
+        default_sensor="Remote",
+        unique_id="123",
+        physical_sensor_name="Physical",
+        use_last_active_sensor=False,
+    )
+    proxy._real_state = physical
+    proxy._update_real_temperature_limits()
+    return proxy
+
+
+@pytest.mark.asyncio
+async def test_swing_features_and_state_are_forwarded(mock_hass):
+    """Expose the physical entity's swing capabilities and state."""
+    proxy = create_proxy(mock_hass)
+
+    assert proxy.supported_features & ClimateEntityFeature.SWING_MODE
+    assert proxy.supported_features & ClimateEntityFeature.SWING_HORIZONTAL_MODE
+    assert proxy.swing_mode == "stop"
+    assert proxy.swing_modes == ["stop", "swing"]
+    assert proxy.swing_horizontal_mode == "stop"
+    assert proxy.swing_horizontal_modes == ["stop", "swing"]
+
+
+@pytest.mark.asyncio
+async def test_vertical_swing_is_forwarded(mock_hass):
+    """Forward vertical swing commands to the physical entity."""
+    proxy = create_proxy(mock_hass)
+
+    await proxy.async_set_swing_mode("swing")
+
+    mock_hass.services.async_call.assert_awaited_with(
+        "climate",
+        "set_swing_mode",
+        {"entity_id": "climate.real", "swing_mode": "swing"},
+        blocking=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_horizontal_swing_is_forwarded(mock_hass):
+    """Forward horizontal swing commands to the physical entity."""
+    proxy = create_proxy(mock_hass)
+
+    await proxy.async_set_swing_horizontal_mode("swing")
+
+    mock_hass.services.async_call.assert_awaited_with(
+        "climate",
+        "set_swing_horizontal_mode",
+        {
+            "entity_id": "climate.real",
+            "swing_horizontal_mode": "swing",
+        },
+        blocking=True,
+    )


### PR DESCRIPTION
## Summary

- Forward vertical and horizontal swing modes from the wrapped climate entity.
- Expose swing-related feature flags and state attributes on the proxy.
- Forward swing-mode service calls to the physical thermostat.
- Add English labels for Daikin Onecta swing values, including windnice -> Comfort Airflow.

Entities without swing support remain unchanged.

## AI assistance

This pull request was prepared with AI assistance and reviewed by the author.