### PR TITLE
Fix target temperature precision handling

### DIFF
--- a/custom_components/thermostat_proxy/climate.py
+++ b/custom_components/thermostat_proxy/climate.py
@@ -1056,30 +1056,56 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
 
     @property
     def target_temperature_step(self) -> float | None:
+        """Return the physical thermostat's supported target step.
+
+        A remote sensor's state formatting describes measurement/display
+        precision, not the resolution that the physical thermostat can accept.
+        In particular, a sensor may report an integer temporarily even though
+        the physical thermostat still supports half-degree targets.
+        """
         base = (
             self._target_temp_step
             or self._precision_override
             or super().target_temperature_step
         )
-        if base is not None:
-            return max(base, self._get_active_sensor_precision())
         return base
 
     @property
     def precision(self) -> float:
+        """Return a display precision supported by Home Assistant.
+
+        Keep the displayed remote-sensor reading as granular as a normal
+        Celsius climate value (tenths), but never let a coarse or noisy sensor
+        state hide valid half-degree thermostat targets.
+        """
+        base = (
+            self._target_temp_step
+            or self._precision_override
+            or super().precision
+        )
         sensor = self._sensor_lookup.get(self._selected_sensor_name)
         if sensor and not sensor.is_physical:
-            return self._sensor_precisions.get(sensor.entity_id, DEFAULT_PRECISION)
-        if self._precision_override is not None:
-            return self._precision_override
-        return super().precision
+            sensor_precision = self._get_active_sensor_display_precision()
+            if base is not None:
+                return min(base, sensor_precision)
+            return sensor_precision
+        return base
 
     def _get_active_sensor_precision(self) -> float:
         """Return the active sensor's inferred precision, or DEFAULT_PRECISION."""
         sensor = self._sensor_lookup.get(self._selected_sensor_name)
         if not sensor or sensor.is_physical:
-            return 0  # Physical sensor doesn't constrain — thermostat precision governs
+            return 0
         return self._sensor_precisions.get(sensor.entity_id, DEFAULT_PRECISION)
+
+    def _get_active_sensor_display_precision(self) -> float:
+        """Return a Home Assistant-compatible precision for the active sensor."""
+        inferred = self._get_active_sensor_precision()
+        # Home Assistant climate display precision is whole degrees or tenths
+        # (with half-degree support where the physical entity requires it).
+        # Floating-point artifacts such as 23.2000007629395 must not become a
+        # tiny precision that makes the frontend round targets to whole degrees.
+        return 1.0 if inferred >= 1.0 else DEFAULT_PRECISION
 
     def _infer_sensor_precision(self, state: State | None) -> float:
         """Infer precision from a sensor state's decimal places."""

--- a/tests/components/thermostat_proxy/test_climate.py
+++ b/tests/components/thermostat_proxy/test_climate.py
@@ -70,11 +70,11 @@ async def test_infer_sensor_precision(mock_hass):
 
 
 @pytest.mark.asyncio
-async def test_effective_precision_coarsest_wins(mock_hass):
-    """Test that precision and target_temp_step use the coarsest available."""
+async def test_precision_and_step_handling(mock_hass):
+    """Test that precision and target_temp_step handle coarse and fine sensors correctly."""
     proxy = create_proxy(mock_hass, target_temp_step=0.5)
 
-    # Sensor 1 reports 1.0 precision
+    # Sensor 1 reports 1.0 precision (coarse)
     mock_hass.states.get.side_effect = lambda entity_id: (
         State(entity_id, "22") if entity_id == "sensor.1" else proxy._real_state
     )
@@ -85,18 +85,21 @@ async def test_effective_precision_coarsest_wins(mock_hass):
     )
     proxy._selected_sensor_name = "Sensor 1"
 
-    # Thermostat is 0.5, Sensor is 1.0 -> Effective is 1.0
-    assert proxy.precision == 1.0
-    assert proxy.target_temperature_step == 1.0
+    # Thermostat step is 0.5. Even with coarse sensor (1.0), we preserve half-degree targets.
+    # Display precision also correctly snaps to 0.5 instead of losing half-degree display.
+    assert proxy.precision == 0.5
+    assert proxy.target_temperature_step == 0.5
 
-    # Switch to high precision sensor
+    # Switch to high precision sensor (0.01)
     proxy._sensor_states["sensor.1"] = State("sensor.1", "22.85")
     proxy._sensor_precisions["sensor.1"] = proxy._infer_sensor_precision(
         State("sensor.1", "22.85")
     )
 
-    # Thermostat is 0.5, Sensor is 0.01 -> Display precision is 0.01, target step is 0.5
-    assert proxy.precision == 0.01
+    # Thermostat is 0.5, Sensor inferred is 0.01.
+    # Sensor display precision caps at 0.1 (DEFAULT_PRECISION). min(0.5, 0.1) -> 0.1
+    # Target step stays 0.5.
+    assert proxy.precision == 0.1
     assert proxy.target_temperature_step == 0.5
 
 

--- a/tests/components/thermostat_proxy/test_climate.py
+++ b/tests/components/thermostat_proxy/test_climate.py
@@ -123,8 +123,9 @@ async def test_log_formatting_preserves_decimals(mock_hass):
 async def test_pending_request_tolerance_covers_step(mock_hass):
     """Test that _pending_request_tolerance does not incorrectly incorporate target_temp_step to avoid ignoring manual changes."""
     proxy = create_proxy(mock_hass, target_temp_step=0.5)
-    proxy._sensor_precisions["sensor.1"] = 0.5
-    # With 0.5 precision, precision / 2 is 0.25.
-    # It should not use step (0.5), so tolerance should be 0.25.
+    proxy._sensor_precisions["sensor.1"] = 1.0
+    # With coarse sensor (1.0), precision resolves to 0.5 (min of step and sensor).
+    # precision / 2 is 0.25.
+    # It should not use step (0.5) directly to increase tolerance, so tolerance should be 0.25.
     tolerance = proxy._pending_request_tolerance()
     assert tolerance == 0.25


### PR DESCRIPTION
## Summary

- Preserve the physical thermostat target step independently from sensor display precision.
- Keep half-degree target control available when the external sensor temporarily reports whole degrees.
- Expose compatible display precision so current and target temperatures are not incorrectly rounded to whole degrees.
- Avoid floating-point sensor artifacts affecting displayed precision.

## AI assistance

This pull request was prepared with AI assistance and reviewed by the author.