### PR TITLE
Fix overdrive short-cycling with sticky hysteresis logic

### DIFF
--- a/custom_components/thermostat_proxy/climate.py
+++ b/custom_components/thermostat_proxy/climate.py
@@ -391,6 +391,8 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         self._realign_trigger_source: str | None = None
         self._cooldown_timer_unsub: Callable[[], None] | None = None
         self._sensor_precisions: dict[str, float] = {}
+        self._active_overdrive_heat: bool = False
+        self._active_overdrive_cool: bool = False
 
     def _log_debug(self, msg: str, *args: Any) -> None:
         """Log diagnostic information."""
@@ -1252,6 +1254,10 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         async with self._command_lock:
+            # Reset overdrive state on manual temperature change
+            self._active_overdrive_heat = False
+            self._active_overdrive_cool = False
+
             # Handle dual setpoints for range-based modes (Auto/Heat-Cool)
             high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
             low = kwargs.get(ATTR_TARGET_TEMP_LOW)
@@ -1420,6 +1426,10 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         self._log_debug("async_set_hvac_mode called with mode: %s", hvac_mode)
+        # Reset overdrive state on mode change
+        self._active_overdrive_heat = False
+        self._active_overdrive_cool = False
+
         await self.hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
@@ -1838,15 +1848,19 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
             if self._real_state and self.hvac_mode in (HVACMode.HEAT, HVACMode.COOL):
                 real_action = self._real_state.attributes.get(ATTR_HVAC_ACTION)
                 tolerance = max(self.precision or DEFAULT_PRECISION, 0.1)
+                deadband = max(tolerance, self._sensor_change_threshold)
 
                 # Heat Mode Stall
                 if self.hvac_mode == HVACMode.HEAT:
-                    # We want heat, but we aren't heating
-                    want_heat = self._virtual_target_temperature > (
-                        sensor_temp + tolerance
-                    )
+                    # Hysteresis: start when exceeding deadband, maintain until target met
+                    if not self._active_overdrive_heat:
+                        want_heat = self._virtual_target_temperature > (sensor_temp + deadband)
+                    else:
+                        want_heat = self._virtual_target_temperature > (sensor_temp + tolerance)
+                        
                     not_heating = real_action != HVACAction.HEATING
-                    if want_heat and not_heating:
+                    if want_heat and (not_heating or self._active_overdrive_heat):
+                        self._active_overdrive_heat = True
                         overdrive_active = True
                         # Push target up to force start
                         overdrive_adjust = (
@@ -1856,15 +1870,20 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                             "Overdrive active: Heating required but thermostat idle. Applying +%s offset.",
                             overdrive_adjust,
                         )
+                    else:
+                        self._active_overdrive_heat = False
 
                 # Cool Mode Stall
                 elif self.hvac_mode == HVACMode.COOL:
-                    # We want cool, but we aren't cooling
-                    want_cool = self._virtual_target_temperature < (
-                        sensor_temp - tolerance
-                    )
+                    # Hysteresis: start when exceeding deadband, maintain until target met
+                    if not self._active_overdrive_cool:
+                        want_cool = self._virtual_target_temperature < (sensor_temp - deadband)
+                    else:
+                        want_cool = self._virtual_target_temperature < (sensor_temp - tolerance)
+
                     not_cooling = real_action != HVACAction.COOLING
-                    if want_cool and not_cooling:
+                    if want_cool and (not_cooling or self._active_overdrive_cool):
+                        self._active_overdrive_cool = True
                         overdrive_active = True
                         # Push target down to force start
                         overdrive_adjust = OVERDRIVE_ADJUSTMENT_COOL
@@ -1872,6 +1891,8 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
                             "Overdrive active: Cooling required but thermostat idle. Applying %s offset.",
                             overdrive_adjust,
                         )
+                    else:
+                        self._active_overdrive_cool = False
 
             if overdrive_active:
                 calculated_real_target = calculated_real_target + overdrive_adjust
@@ -2001,36 +2022,47 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
         ):
             real_action = self._real_state.attributes.get(ATTR_HVAC_ACTION)
             tolerance = max(self.precision or DEFAULT_PRECISION, 0.1)
+            deadband = max(tolerance, self._sensor_change_threshold)
 
             if (
                 self._virtual_target_temperature_low is not None
                 and calculated_real_low is not None
             ):
-                want_heat = sensor_temp < (
-                    self._virtual_target_temperature_low - tolerance
-                )
+                if not self._active_overdrive_heat:
+                    want_heat = sensor_temp < (self._virtual_target_temperature_low - deadband)
+                else:
+                    want_heat = sensor_temp < (self._virtual_target_temperature_low - tolerance)
+                    
                 not_heating = real_action != HVACAction.HEATING
-                if want_heat and not_heating:
+                if want_heat and (not_heating or self._active_overdrive_heat):
+                    self._active_overdrive_heat = True
                     overdrive_adjust_low = OVERDRIVE_ADJUSTMENT_HEAT
                     _LOGGER.info(
                         "Overdrive active (dual low): Heating required but thermostat idle. Applying +%s offset.",
                         overdrive_adjust_low,
                     )
+                else:
+                    self._active_overdrive_heat = False
 
             if (
                 self._virtual_target_temperature_high is not None
                 and calculated_real_high is not None
             ):
-                want_cool = sensor_temp > (
-                    self._virtual_target_temperature_high + tolerance
-                )
+                if not self._active_overdrive_cool:
+                    want_cool = sensor_temp > (self._virtual_target_temperature_high + deadband)
+                else:
+                    want_cool = sensor_temp > (self._virtual_target_temperature_high + tolerance)
+                    
                 not_cooling = real_action != HVACAction.COOLING
-                if want_cool and not_cooling:
+                if want_cool and (not_cooling or self._active_overdrive_cool):
+                    self._active_overdrive_cool = True
                     overdrive_adjust_high = OVERDRIVE_ADJUSTMENT_COOL
                     _LOGGER.info(
                         "Overdrive active (dual high): Cooling required but thermostat idle. Applying %s offset.",
                         overdrive_adjust_high,
                     )
+                else:
+                    self._active_overdrive_cool = False
 
         if calculated_real_low is not None and overdrive_adjust_low != 0.0:
             calculated_real_low += overdrive_adjust_low

--- a/tests/components/thermostat_proxy/test_climate.py
+++ b/tests/components/thermostat_proxy/test_climate.py
@@ -129,3 +129,79 @@ async def test_pending_request_tolerance_covers_step(mock_hass):
     # It should not use step (0.5) directly to increase tolerance, so tolerance should be 0.25.
     tolerance = proxy._pending_request_tolerance()
     assert tolerance == 0.25
+
+@pytest.mark.asyncio
+async def test_overdrive_short_cycling_and_threshold(mock_hass):
+    """Test that overdrive respects the threshold as a deadband and remains sticky."""
+    proxy = create_proxy(mock_hass, target_temp_step=0.1)
+    proxy._sensor_change_threshold = 0.5
+    proxy._virtual_target_temperature = 72.6
+    proxy._last_real_target_temp = 72.6
+    proxy._selected_sensor_name = "Sensor 1"
+    
+    mock_real_state = State(
+        "climate.real",
+        HVACMode.COOL,
+        {
+            "current_temperature": 72.6,
+            "temperature": 72.6,
+            "target_temp_step": 0.1,
+            "hvac_action": "idle",
+        },
+    )
+    
+    mock_sensor_state = State("sensor.1", "72.6")
+    
+    def mock_get(entity_id):
+        if entity_id == "climate.real": return mock_real_state
+        if entity_id == "sensor.1": return mock_sensor_state
+        return None
+        
+    mock_hass.states.get.side_effect = mock_get
+    proxy._real_state = mock_real_state
+    proxy._sensor_states["sensor.1"] = mock_sensor_state
+    
+    # Run a dummy sync to setup state
+    await proxy._async_realign_real_target_from_sensor(trigger_source="sensor")
+    assert not proxy._active_overdrive_cool
+    
+    # Case 1: Room warms up slightly to 72.9 (within 0.5 threshold)
+    mock_sensor_state = State("sensor.1", "72.9")
+    proxy._sensor_states["sensor.1"] = mock_sensor_state
+    await proxy._async_realign_real_target_from_sensor(trigger_source="cooldown_expired")
+    # Should NOT trigger overdrive because 72.6 < (72.9 - 0.5) is False
+    assert not proxy._active_overdrive_cool
+    
+    # Case 2: Room warms up to 73.2 (exceeds 0.5 threshold deadband)
+    mock_sensor_state = State("sensor.1", "73.2")
+    proxy._sensor_states["sensor.1"] = mock_sensor_state
+    await proxy._async_realign_real_target_from_sensor(trigger_source="cooldown_expired")
+    # SHOULD trigger overdrive because 72.6 < (73.2 - 0.5) is True
+    assert proxy._active_overdrive_cool
+    
+    # Case 3: The physical thermostat starts cooling, but then stops prematurely (short cycling simulation)
+    # The room dropped to 73.0. 73.0 is within the threshold but above the target.
+    mock_real_state = State(
+        "climate.real",
+        HVACMode.COOL,
+        {
+            "current_temperature": 73.0,
+            "temperature": 71.6, # target pushed down
+            "target_temp_step": 0.1,
+            "hvac_action": "idle", # Premature idle
+        },
+    )
+    mock_sensor_state = State("sensor.1", "73.0")
+    proxy._real_state = mock_real_state
+    proxy._sensor_states["sensor.1"] = mock_sensor_state
+    
+    await proxy._async_realign_real_target_from_sensor(trigger_source="cooldown_expired")
+    # Overdrive should still be true because we haven't reached target yet (72.6 < 73.0 - 0.1)!
+    assert proxy._active_overdrive_cool
+
+    # Case 4: Target is finally met
+    mock_sensor_state = State("sensor.1", "72.5")
+    proxy._sensor_states["sensor.1"] = mock_sensor_state
+    await proxy._async_realign_real_target_from_sensor(trigger_source="cooldown_expired")
+    # Target reached, overdrive should deactivate
+    assert not proxy._active_overdrive_cool


### PR DESCRIPTION
## Summary

This PR addresses an equipment short-cycling issue where overdrive would repeatedly trigger, clear, and re-trigger every 60 seconds (or cooldown interval) when the physical thermostat entered an idle state while the room was still off-target.

## Changes

- **Sticky Overdrive State**: Introduced `_active_overdrive_heat` and `_active_overdrive_cool` instance flags to keep overdrive engaged once activated until the target temperature is satisfied.
- **Deadband Hysteresis**: Incorporated `sensor_change_threshold` as a deadband when deciding whether to *start* overdrive. Overdrive only engages when the room temperature deviates beyond the configured threshold, but remains active until the target is fully met.
- **Manual Reset**: Clear overdrive state on manual temperature or HVAC mode changes.
- **Unit Tests**: Added `test_overdrive_short_cycling_and_threshold` covering deadband filtering, overdrive activation, short-cycling persistence, and target satisfaction.