### PR TITLE
fix: translate Daikin swing-mode labels

### DIFF
--- a/custom_components/thermostat_proxy/climate.py
+++ b/custom_components/thermostat_proxy/climate.py
@@ -310,6 +310,7 @@ class CustomThermostatEntity(RestoreEntity, ClimateEntity):
     """Thermostat proxy that can borrow any temperature sensor."""
 
     _attr_should_poll = False
+    _attr_translation_key = "thermostat_proxy"
 
     def __init__(
         self,

--- a/custom_components/thermostat_proxy/strings.json
+++ b/custom_components/thermostat_proxy/strings.json
@@ -1,20 +1,22 @@
 {
   "title": "Thermostat Proxy",
-  "entity_component": {
+  "entity": {
     "climate": {
-      "state_attributes": {
-        "swing_mode": {
-          "state": {
-            "stop": "Stop",
-            "swing": "Swing",
-            "floorheatingairflow": "FloorHeating Airflow",
-            "windnice": "Comfort Airflow"
-          }
-        },
-        "swing_horizontal_mode": {
-          "state": {
-            "stop": "Stop",
-            "swing": "Swing"
+      "thermostat_proxy": {
+        "state_attributes": {
+          "swing_mode": {
+            "state": {
+              "stop": "Stop",
+              "swing": "Swing",
+              "floorheatingairflow": "FloorHeating Airflow",
+              "windnice": "Comfort Airflow"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "stop": "Stop",
+              "swing": "Swing"
+            }
           }
         }
       }

--- a/custom_components/thermostat_proxy/translations/en.json
+++ b/custom_components/thermostat_proxy/translations/en.json
@@ -1,20 +1,22 @@
 {
   "title": "Thermostat Proxy",
-  "entity_component": {
+  "entity": {
     "climate": {
-      "state_attributes": {
-        "swing_mode": {
-          "state": {
-            "stop": "Stop",
-            "swing": "Swing",
-            "floorheatingairflow": "FloorHeating Airflow",
-            "windnice": "Comfort Airflow"
-          }
-        },
-        "swing_horizontal_mode": {
-          "state": {
-            "stop": "Stop",
-            "swing": "Swing"
+      "thermostat_proxy": {
+        "state_attributes": {
+          "swing_mode": {
+            "state": {
+              "stop": "Stop",
+              "swing": "Swing",
+              "floorheatingairflow": "FloorHeating Airflow",
+              "windnice": "Comfort Airflow"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "stop": "Stop",
+              "swing": "Swing"
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Translate Daikin Onecta swing-mode labels in Thermostat Proxy.
- Keep raw values for commands.